### PR TITLE
fix ImageOptim.m initialize()

### DIFF
--- a/imageoptim/ImageOptim.h
+++ b/imageoptim/ImageOptim.h
@@ -37,7 +37,7 @@
 -(IBAction)browseForFiles:(id)sender;
 
 + (void)initialize;
-
++(void)regDefs;
 +(int)numberOfCPUs;
 
 @property (copy,nonatomic) NSIndexSet* selectedIndexes;


### PR DESCRIPTION
ImageOptim.m initialize() is currently called twice on app init. 

This patch ensures reg defaults, migrate old defaults and numberOfCPUs are only called once.
