### PR TITLE
Fix minor markdown formatting error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#ImageOptim
+# ImageOptim
 
 [ImageOptim](http://imageoptim.com) is a GUI for lossless image optimization tools: PNGOUT, AdvPNG, Pngcrush, OptiPNG, JpegOptim, MozJPEG, jpegtran, and Gifsicle.
 


### PR DESCRIPTION
Markdown headers only get formatted if there's a space after the number sign(s).