### PR TITLE
Tweak credits text color to be white on darkmode

### DIFF
--- a/imageoptim/ImageOptimController.m
+++ b/imageoptim/ImageOptimController.m
@@ -70,6 +70,7 @@ static const char *kIMPreviewPanelContext = "preview";
 
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:kJobQueueFinished object:filesController];
+    [credits removeObserver:self forKeyPath:@"effectiveAppearance"];
 }
 
 - (void)handleServices:(NSPasteboard *)pboard
@@ -231,6 +232,7 @@ static void appendFormatNameIfLossyEnabled(NSUserDefaults *defs, NSString *name,
 
     // this creates and sets the text for textview
     [self performSelectorInBackground:@selector(loadCreditsHTML:) withObject:nil];
+    [credits addObserver:self forKeyPath:@"effectiveAppearance" options:0 context:nil];
 }
 
 - (void)loadCreditsHTML:(id)_unused {

--- a/imageoptim/ImageOptimController.m
+++ b/imageoptim/ImageOptimController.m
@@ -255,6 +255,7 @@ static void appendFormatNameIfLossyEnabled(NSUserDefaults *defs, NSString *name,
       [creditsRef setEditable:YES];
       [creditsRef insertText:tmpStr replacementRange:NSMakeRange(0, 0)];
       [creditsRef setEditable:NO];
+      [self adaptCreditsAppearance];
     });
 }
 
@@ -268,9 +269,17 @@ static void appendFormatNameIfLossyEnabled(NSUserDefaults *defs, NSString *name,
     return false;
 }
 
+- (void)adaptCreditsAppearance {
+    credits.textColor = [self isDarkMode] ? [NSColor whiteColor] : [NSColor blackColor];
+}
+
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
     // Defer and coalesce statusbar updates
     dispatch_source_merge_data(statusBarUpdateQueue, 1);
+
+    if (object == credits && [keyPath isEqualToString:@"effectiveAppearance"]) {
+        [self adaptCreditsAppearance];
+    }
 
     if (context == kIMPreviewPanelContext) {
         [previewPanel reloadData];

--- a/imageoptim/ImageOptimController.m
+++ b/imageoptim/ImageOptimController.m
@@ -256,6 +256,16 @@ static void appendFormatNameIfLossyEnabled(NSUserDefaults *defs, NSString *name,
     });
 }
 
+- (BOOL)isDarkMode {
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
+    if (@available(macOS 10.14, *)) {
+        NSAppearanceName bestAppearance = [credits.effectiveAppearance bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
+        return [bestAppearance isEqualToString: NSAppearanceNameDarkAqua] ? true : false;
+    }
+#endif
+    return false;
+}
+
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
     // Defer and coalesce statusbar updates
     dispatch_source_merge_data(statusBarUpdateQueue, 1);

--- a/imageoptim/ImageOptimController.m
+++ b/imageoptim/ImageOptimController.m
@@ -262,7 +262,7 @@ static void appendFormatNameIfLossyEnabled(NSUserDefaults *defs, NSString *name,
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
     if (@available(macOS 10.14, *)) {
         NSAppearanceName bestAppearance = [credits.effectiveAppearance bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
-        return [bestAppearance isEqualToString: NSAppearanceNameDarkAqua] ? true : false;
+        return [bestAppearance isEqualToString: NSAppearanceNameDarkAqua];
     }
 #endif
     return false;

--- a/imageoptim/ImageOptimController.m
+++ b/imageoptim/ImageOptimController.m
@@ -250,11 +250,10 @@ static void appendFormatNameIfLossyEnabled(NSUserDefaults *defs, NSString *name,
         documentAttributes:nil];
 
 
-    NSTextView *creditsRef = credits;
     dispatch_async(dispatch_get_main_queue(), ^() {
-      [creditsRef setEditable:YES];
-      [creditsRef insertText:tmpStr replacementRange:NSMakeRange(0, 0)];
-      [creditsRef setEditable:NO];
+      [self->credits setEditable:YES];
+      [self->credits insertText:tmpStr replacementRange:NSMakeRange(0, 0)];
+      [self->credits setEditable:NO];
       [self adaptCreditsAppearance];
     });
 }


### PR DESCRIPTION
Closes #270 

This PR changes the color of the credits text to adjust according to light vs dark mode. This increases the readability of the text in dark mode. 

~ | Light | Dark
--|--|--
Before | <img width="312" alt="before light" src="https://user-images.githubusercontent.com/5240843/46585234-70d1c400-ca2b-11e8-9d44-681b56363425.png"> | <img width="312" alt="before dark" src="https://user-images.githubusercontent.com/5240843/46585235-70d1c400-ca2b-11e8-8e09-99003cfaf475.png">
After | <img width="312" alt="light" src="https://user-images.githubusercontent.com/5240843/46585116-cdcc7a80-ca29-11e8-8618-94c9461c879d.png"> | <img width="312" alt="dark" src="https://user-images.githubusercontent.com/5240843/46585117-cdcc7a80-ca29-11e8-8456-3e50a6167958.png">