### PR TITLE
Only strip XML processing instructions in lossy mode.

### DIFF
--- a/svgo/index.js
+++ b/svgo/index.js
@@ -18,7 +18,6 @@ const defaults = [
     'removeEmptyContainers',
     'removeEmptyText',
     'removeNonInheritableGroupAttrs',
-    'removeXMLProcInst',
     'sortAttrs',
 ];
 
@@ -48,6 +47,7 @@ const lossy = [
     'removeUselessStrokeAndFill',
     'removeViewBox',
     'removeXMLNS',
+    'removeXMLProcInst',
 ];
 
 


### PR DESCRIPTION
### Issue summary
- To be recognised as `image/svg+xml` mime type, SVGs require `<?xml version="1.0" encoding="utf-8"?>` declaration as the first line of the file
- Current implementation means that, by default, SVGs run through ImageOptim will likely not be accepted by file uploaders. For example, the Wordpress Media Library
- By default, ImageOptim should output valid mime type SVGs
- Moving `removeXMLProcInst` to the lossy mode config achieves this goal but still allows for aggressive compression at users choice

### Questions
- Unsure if this code change is enough to be accepted here at source or if the project also needs to be built in xcode?