### PR TITLE
Fix wrong translation

### DIFF
--- a/imageoptim/zh-Hans.lproj/ImageOptim.strings
+++ b/imageoptim/zh-Hans.lproj/ImageOptim.strings
@@ -47,7 +47,7 @@
 "239.ibExternalAccessibilityDescription" = "优化后的文件大小";
 
 /* Table Column Title (MUST BE SHORT) "Savings" */
-"243.headerCell.title" = "保存";
+"243.headerCell.title" = "已节省";
 
 /* TextField Tooltip "Status" */
 "294.ibExternalAccessibilityDescription" = "状态";


### PR DESCRIPTION
The Chinese translation for `Savings` on the main window is completely wrong. This pull request fixed it.