### PR TITLE
modern XCode & M1 support

### DIFF
--- a/advpng/Makefile
+++ b/advpng/Makefile
@@ -3,7 +3,7 @@ build: all
 all: repng.cc
 
 repng.cc:
-	curl -L http://sourceforge.net/projects/advancemame/files/advancecomp/1.15/advancecomp-1.15.tar.gz/download | tar xz --strip-components=1
+	curl -L https://snapshot.debian.org/archive/debian/20120101T000000Z/pool/main/a/advancecomp/advancecomp_1.15.orig.tar.gz | tar xz --strip-components=1
 
 clean:
 

--- a/libpng/Makefile
+++ b/libpng/Makefile
@@ -7,6 +7,7 @@ all: png.h
 
 png.h: /tmp/$(OPTIPNG_FILENAME)
 	tar xzf /tmp/$(OPTIPNG_FILENAME) --strip-components=3 --exclude=Makefile optipng-$(VERSION)/lib/libpng
+	sed -i.bak 's/defined(TARGET_OS_MAC)/0/' pngconf.h && rm pngconf.h.bak
 
 /tmp/$(OPTIPNG_FILENAME):
 	curl -L http://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-$(VERSION)/$(OPTIPNG_FILENAME) -o /tmp/$(OPTIPNG_FILENAME)


### PR DESCRIPTION
Refs #334.

This is the smallest patch I could reduce the build to in order to produce a working `ImageOptim.app` on Apple Silicon under the current toolchain (tested on Xcode 26.4.1, macOS 26.4.1). Echoing your earlier comment in #334 — *"support depends only on using appropriate compilers and settings in build systems"* — the project's existing settings already do the right thing on M1 in practice: every active Xcode project inherits `ARCHS_STANDARD = arm64 x86_64`, the Rust tools handle their own arch selection via `cargo-xcode`, and `pngout` is already shipped as a universal binary.

What was blocking the build was two unrelated cases of upstream bitrot:

1. **`advpng/Makefile`** — the SourceForge URL for `advancecomp 1.15` no longer serves the tarball (returns an HTML download page), and 1.15 is gone from upstream entirely (the GitHub releases for `amadvance/advancecomp` begin at 1.20, with restructured source incompatible with this Xcode project). Switched to `snapshot.debian.org`, which keeps historical Debian source tarballs indefinitely. The `.orig.tar.gz` it serves is the upstream tarball unmodified.

2. **`libpng/Makefile`** — `libpng-1.4.5` (vendored via `optipng-0.6.5`) `#include`s `<fp.h>` when `TARGET_OS_MAC` is set in `pngconf.h`. Modern Xcode/clang auto-defines `TARGET_OS_MAC=1` on darwin, so the build hits a Carbon-era header that was removed from the macOS SDK years ago. Added a one-line `sed` after extraction that neutralises the conditional, letting it fall through to `<math.h>` like every other platform.

Neither change is arch-specific — they happen to keep Intel builds working too. 

This PR doesn't touch the signing/notarisation situation discussed later in #334 — only the build itself. Marked as draft accordingly so you can decide whether the framing fits before merging.

### Verified

- `xcodebuild -arch arm64` produces a clean `ImageOptim.app` (native arm64).
- All bundled tools present in the resulting bundle: `advpng`, `gifsicle`, `guetzli`, `jpegoptim`, `jpegtran`, `libimageoptimjpeg.dylib`, `liblibpng.dylib`, `oxipng`, `pngcrush`, `pngout`, `pngquant`, `svgcleaner`, `svgo.js`, `zopflipng`.
- Diff is 3 lines across 2 files.