### PR TITLE
Fix: Apple Silicon performance — stop pinning workers to efficiency cores

### DIFF
--- a/imageoptim/Backend/Workers/CommandWorker.m
+++ b/imageoptim/Backend/Workers/CommandWorker.m
@@ -93,8 +93,12 @@
         }
         [task launch];
 
-        int pid = [task processIdentifier];
-        if (pid > 1) setpriority(PRIO_PROCESS, pid, PRIO_MAX / 2); // PRIO_MAX is minimum priority. POSIX is intuitive.
+        // On Apple Silicon, setpriority causes scheduler to pin to E-cores.
+        // Only deprioritize when RunLowPriority is explicitly enabled.
+        if (self.qualityOfService == NSQualityOfServiceUtility) {
+            int pid = [task processIdentifier];
+            if (pid > 1) setpriority(PRIO_PROCESS, pid, PRIO_MAX / 2);
+        }
     }
     @catch (NSException *e) {
         IOWarn("Failed to launch %@ - %@", [self className], e);

--- a/imageoptim/defaults.plist
+++ b/imageoptim/defaults.plist
@@ -43,7 +43,7 @@
 	<key>RunConcurrentFiles</key>
 	<integer>4</integer>
 	<key>RunLowPriority</key>
-	<true/>
+	<false/>
 	<key>BounceDock</key>
 	<true/>
 </dict>


### PR DESCRIPTION
## Problem

ImageOptim is significantly slower on Apple Silicon Macs (M1/M2/M3) compared to equivalent or older Intel machines.

## Root Cause

Two mechanisms combine to force all compression subprocesses onto Apple Silicon's **efficiency cores** (which are 3-4x slower than performance cores):

1. **`RunLowPriority` defaults to `true`** — sets all worker queues to `NSQualityOfServiceUtility`, which macOS maps to E-cores on Apple Silicon.
2. **Unconditional `setpriority(PRIO_PROCESS, pid, PRIO_MAX/2)`** in `CommandWorker.m` — further deprioritizes every spawned tool (advpng, pngcrush, jpegoptim, etc.) regardless of the user's preference.

On Intel, lower priority just meant slightly less CPU time since all cores ran at the same clock speed. On Apple Silicon's asymmetric architecture, it means confinement to the slow cores.

## Fix

- **`defaults.plist`**: Change `RunLowPriority` default to `false`. Modern macOS QoS handles resource management without manual deprioritization.
- **`CommandWorker.m`**: Only call `setpriority()` when the user has explicitly enabled low-priority mode (i.e., QoS is `Utility`).

## Impact

**Apple Silicon** — dramatic speed improvement. P-cores are now used for compression work by default instead of being confined to E-cores.

**Intel** — safe, no regression. Intel CPUs have symmetric cores, so QoS level only affects scheduling priority relative to other processes, not which cores are used. Removing the unconditional `setpriority()` means compression tools get fair CPU time instead of being artificially deprioritized — a minor speed improvement if anything.

**Both architectures** — the "Run in low priority" preference continues to work. Users who explicitly want background operation still get the deprioritized behavior (`NSQualityOfServiceUtility` + `setpriority()`) on both Intel and Apple Silicon.

## Workaround (no rebuild needed)

```bash
defaults write net.pornel.ImageOptim RunLowPriority -bool false
```
