### PR TITLE
Allow overriding the pngout codesign identity

### DIFF
--- a/imageoptim/Makefile
+++ b/imageoptim/Makefile
@@ -1,5 +1,6 @@
 HELPINDEXES=$(addsuffix Help.helpindex, $(wildcard *.lproj/Help/))
 SUBMODULES=../Sparkle/Sparkle ../svgcleaner/src
+CODESIGN_IDENTITY ?= Developer ID
 
 build: all
 
@@ -12,7 +13,7 @@ pngout:
 	curl -LO https://www.jonof.id.au/files/kenutils/pngout-20230322-mac.zip
 	unzip -p pngout-20230322-mac.zip pngout-20230322-mac/pngout > pngout
 	chmod a+rx pngout
-	codesign -s "Developer ID" ./pngout --force
+	codesign -s "$(CODESIGN_IDENTITY)" ./pngout --force
 
 clean:
 	-rm -rf pngout pngout-20230322-mac.zip


### PR DESCRIPTION
`imageoptim/Makefile` hardcodes the signing identity for the downloaded pngout binary:

```make
codesign -s "Developer ID" ./pngout --force
```

On any machine without that certificate this aborts the entire build:

```
codesign -s "Developer ID" ./pngout --force
Developer ID: no identity found
make: *** [pngout] Error 1
** BUILD INTERRUPTED **
The following build commands failed:
	ExternalBuildToolExecution downloads (in target 'downloads' from project 'ImageOptim')
```

The other signing settings can be overridden from the command line, but this one cannot: `downloads` is an external build tool target running a plain Makefile, so `xcodebuild`'s `CODE_SIGN_IDENTITY` never reaches it. Editing the file is currently the only way to build locally.

This makes the identity a variable, defaulting to the current value so release builds are unaffected:

```sh
make CODESIGN_IDENTITY=-          # ad-hoc, for local builds
CODESIGN_IDENTITY=- xcodebuild …  # also works, since Xcode exports the environment
```

Verified by building `ImageOptim.app` from a clean clone on macOS 27 / Xcode 27, with `CODESIGN_IDENTITY=-`, and confirming the resulting app launches and optimizes images.

Two other problems block a from-scratch build today; both are filed separately rather than bundled here, since the right fix is a maintainer call:

- #467 — `MACOSX_DEPLOYMENT_TARGET` 10.15 is below Xcode 27's supported range
- #468 — `svgo.js` fails to build because webpack can't resolve `@ljharb/tsconfig`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
