### PR TITLE
Update libpng to 1.6.58, zlib to 1.3.2, pngcrush to 1.8.13 and advancecomp to 2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,12 @@ libpng/*-optipng.diff
 libpng/*.3
 libpng/*.c
 libpng/*.in
+libpng/arm
+libpng/intel
+libpng/loongarch
+libpng/mips
+libpng/powerpc
+libpng/riscv
 libpng/*.jpg
 libpng/*.m4
 libpng/*.png
@@ -113,7 +119,11 @@ libpng/mkinstalldirs
 libpng/png.5
 libpng/png.h
 libpng/pngconf.h
+libpng/pngdebug.h
+libpng/pnginfo.h
+libpng/pnglibconf.h
 libpng/pngpriv.h
+libpng/pngstruct.h
 libpng/pngusr.h
 libpng/projects
 libpng/README

--- a/advpng/Makefile
+++ b/advpng/Makefile
@@ -1,11 +1,20 @@
+VERSION=2.6
+
 build: all
 
 all: repng.cc
 
 repng.cc:
-	curl -L https://snapshot.debian.org/archive/debian/20120101T000000Z/pool/main/a/advancecomp/advancecomp_1.15.orig.tar.gz | tar xz --strip-components=1
+	curl -sL https://github.com/amadvance/advancecomp/releases/download/v$(VERSION)/advancecomp-$(VERSION).tar.gz | \
+	  tar xz --strip-components=1 --exclude='Makefile'
 
 clean:
+	# config.h is ours and tracked; everything else here is extracted.
+	-rm -rf *.c *.cc 7z lib libdeflate zopfli doc test \
+	  aclocal.m4 autogen.sh autover.sh compile config.guess config.sub \
+	  configure configure.ac install-sh missing Makefile.am Makefile.in \
+	  AUTHORS COPYING HISTORY INSTALL README
+	-find . -maxdepth 1 -name '*.h' ! -name config.h -delete
 
 install:
 

--- a/advpng/advpng.xcodeproj/project.pbxproj
+++ b/advpng/advpng.xcodeproj/project.pbxproj
@@ -7,6 +7,30 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AD00BUILD000000000000000 /* portable.c in Sources */ = {isa = PBXBuildFile; fileRef = AD00FILE0000000000000000 /* portable.c */; };
+		AD01BUILD000000000000000 /* libdeflate/arm/cpu_features.c in Sources */ = {isa = PBXBuildFile; fileRef = AD01FILE0000000000000000 /* libdeflate/arm/cpu_features.c */; };
+		AD02BUILD000000000000000 /* libdeflate/x86/cpu_features.c in Sources */ = {isa = PBXBuildFile; fileRef = AD02FILE0000000000000000 /* libdeflate/x86/cpu_features.c */; };
+		AD03BUILD000000000000000 /* libdeflate/adler32.c in Sources */ = {isa = PBXBuildFile; fileRef = AD03FILE0000000000000000 /* libdeflate/adler32.c */; };
+		AD04BUILD000000000000000 /* libdeflate/crc32.c in Sources */ = {isa = PBXBuildFile; fileRef = AD04FILE0000000000000000 /* libdeflate/crc32.c */; };
+		AD05BUILD000000000000000 /* libdeflate/deflate_compress.c in Sources */ = {isa = PBXBuildFile; fileRef = AD05FILE0000000000000000 /* libdeflate/deflate_compress.c */; };
+		AD06BUILD000000000000000 /* libdeflate/deflate_decompress.c in Sources */ = {isa = PBXBuildFile; fileRef = AD06FILE0000000000000000 /* libdeflate/deflate_decompress.c */; };
+		AD07BUILD000000000000000 /* libdeflate/gzip_compress.c in Sources */ = {isa = PBXBuildFile; fileRef = AD07FILE0000000000000000 /* libdeflate/gzip_compress.c */; };
+		AD08BUILD000000000000000 /* libdeflate/gzip_decompress.c in Sources */ = {isa = PBXBuildFile; fileRef = AD08FILE0000000000000000 /* libdeflate/gzip_decompress.c */; };
+		AD09BUILD000000000000000 /* libdeflate/utils.c in Sources */ = {isa = PBXBuildFile; fileRef = AD09FILE0000000000000000 /* libdeflate/utils.c */; };
+		AD10BUILD000000000000000 /* libdeflate/zlib_compress.c in Sources */ = {isa = PBXBuildFile; fileRef = AD10FILE0000000000000000 /* libdeflate/zlib_compress.c */; };
+		AD11BUILD000000000000000 /* libdeflate/zlib_decompress.c in Sources */ = {isa = PBXBuildFile; fileRef = AD11FILE0000000000000000 /* libdeflate/zlib_decompress.c */; };
+		AD12BUILD000000000000000 /* zopfli/blocksplitter.c in Sources */ = {isa = PBXBuildFile; fileRef = AD12FILE0000000000000000 /* zopfli/blocksplitter.c */; };
+		AD13BUILD000000000000000 /* zopfli/cache.c in Sources */ = {isa = PBXBuildFile; fileRef = AD13FILE0000000000000000 /* zopfli/cache.c */; };
+		AD14BUILD000000000000000 /* zopfli/deflate.c in Sources */ = {isa = PBXBuildFile; fileRef = AD14FILE0000000000000000 /* zopfli/deflate.c */; };
+		AD15BUILD000000000000000 /* zopfli/gzip_container.c in Sources */ = {isa = PBXBuildFile; fileRef = AD15FILE0000000000000000 /* zopfli/gzip_container.c */; };
+		AD16BUILD000000000000000 /* zopfli/hash.c in Sources */ = {isa = PBXBuildFile; fileRef = AD16FILE0000000000000000 /* zopfli/hash.c */; };
+		AD17BUILD000000000000000 /* zopfli/katajainen.c in Sources */ = {isa = PBXBuildFile; fileRef = AD17FILE0000000000000000 /* zopfli/katajainen.c */; };
+		AD18BUILD000000000000000 /* zopfli/lz77.c in Sources */ = {isa = PBXBuildFile; fileRef = AD18FILE0000000000000000 /* zopfli/lz77.c */; };
+		AD19BUILD000000000000000 /* zopfli/squeeze.c in Sources */ = {isa = PBXBuildFile; fileRef = AD19FILE0000000000000000 /* zopfli/squeeze.c */; };
+		AD20BUILD000000000000000 /* zopfli/tree.c in Sources */ = {isa = PBXBuildFile; fileRef = AD20FILE0000000000000000 /* zopfli/tree.c */; };
+		AD21BUILD000000000000000 /* zopfli/util.c in Sources */ = {isa = PBXBuildFile; fileRef = AD21FILE0000000000000000 /* zopfli/util.c */; };
+		AD22BUILD000000000000000 /* zopfli/zlib_container.c in Sources */ = {isa = PBXBuildFile; fileRef = AD22FILE0000000000000000 /* zopfli/zlib_container.c */; };
+		AD23BUILD000000000000000 /* zopfli/zopfli_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = AD23FILE0000000000000000 /* zopfli/zopfli_lib.c */; };
 		5A4DC4331029FFB700A9DD55 /* fz.c in Sources */ = {isa = PBXBuildFile; fileRef = 5A81664A0EA117B600962CF2 /* fz.c */; };
 		5A8166360EA117B100962CF2 /* repng.cc in Sources */ = {isa = PBXBuildFile; fileRef = 5A81662D0EA117B100962CF2 /* repng.cc */; };
 		5A8166370EA117B100962CF2 /* siglock.cc in Sources */ = {isa = PBXBuildFile; fileRef = 5A81662E0EA117B100962CF2 /* siglock.cc */; };
@@ -80,6 +104,30 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		AD00FILE0000000000000000 /* portable.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = portable.c; path = portable.c; sourceTree = SOURCE_ROOT; };
+		AD01FILE0000000000000000 /* libdeflate/arm/cpu_features.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cpu_features.c; path = libdeflate/arm/cpu_features.c; sourceTree = SOURCE_ROOT; };
+		AD02FILE0000000000000000 /* libdeflate/x86/cpu_features.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cpu_features.c; path = libdeflate/x86/cpu_features.c; sourceTree = SOURCE_ROOT; };
+		AD03FILE0000000000000000 /* libdeflate/adler32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = adler32.c; path = libdeflate/adler32.c; sourceTree = SOURCE_ROOT; };
+		AD04FILE0000000000000000 /* libdeflate/crc32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = crc32.c; path = libdeflate/crc32.c; sourceTree = SOURCE_ROOT; };
+		AD05FILE0000000000000000 /* libdeflate/deflate_compress.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = deflate_compress.c; path = libdeflate/deflate_compress.c; sourceTree = SOURCE_ROOT; };
+		AD06FILE0000000000000000 /* libdeflate/deflate_decompress.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = deflate_decompress.c; path = libdeflate/deflate_decompress.c; sourceTree = SOURCE_ROOT; };
+		AD07FILE0000000000000000 /* libdeflate/gzip_compress.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = gzip_compress.c; path = libdeflate/gzip_compress.c; sourceTree = SOURCE_ROOT; };
+		AD08FILE0000000000000000 /* libdeflate/gzip_decompress.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = gzip_decompress.c; path = libdeflate/gzip_decompress.c; sourceTree = SOURCE_ROOT; };
+		AD09FILE0000000000000000 /* libdeflate/utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = utils.c; path = libdeflate/utils.c; sourceTree = SOURCE_ROOT; };
+		AD10FILE0000000000000000 /* libdeflate/zlib_compress.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = zlib_compress.c; path = libdeflate/zlib_compress.c; sourceTree = SOURCE_ROOT; };
+		AD11FILE0000000000000000 /* libdeflate/zlib_decompress.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = zlib_decompress.c; path = libdeflate/zlib_decompress.c; sourceTree = SOURCE_ROOT; };
+		AD12FILE0000000000000000 /* zopfli/blocksplitter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = blocksplitter.c; path = zopfli/blocksplitter.c; sourceTree = SOURCE_ROOT; };
+		AD13FILE0000000000000000 /* zopfli/cache.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cache.c; path = zopfli/cache.c; sourceTree = SOURCE_ROOT; };
+		AD14FILE0000000000000000 /* zopfli/deflate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = deflate.c; path = zopfli/deflate.c; sourceTree = SOURCE_ROOT; };
+		AD15FILE0000000000000000 /* zopfli/gzip_container.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = gzip_container.c; path = zopfli/gzip_container.c; sourceTree = SOURCE_ROOT; };
+		AD16FILE0000000000000000 /* zopfli/hash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = hash.c; path = zopfli/hash.c; sourceTree = SOURCE_ROOT; };
+		AD17FILE0000000000000000 /* zopfli/katajainen.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = katajainen.c; path = zopfli/katajainen.c; sourceTree = SOURCE_ROOT; };
+		AD18FILE0000000000000000 /* zopfli/lz77.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lz77.c; path = zopfli/lz77.c; sourceTree = SOURCE_ROOT; };
+		AD19FILE0000000000000000 /* zopfli/squeeze.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = squeeze.c; path = zopfli/squeeze.c; sourceTree = SOURCE_ROOT; };
+		AD20FILE0000000000000000 /* zopfli/tree.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = tree.c; path = zopfli/tree.c; sourceTree = SOURCE_ROOT; };
+		AD21FILE0000000000000000 /* zopfli/util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = util.c; path = zopfli/util.c; sourceTree = SOURCE_ROOT; };
+		AD22FILE0000000000000000 /* zopfli/zlib_container.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = zlib_container.c; path = zopfli/zlib_container.c; sourceTree = SOURCE_ROOT; };
+		AD23FILE0000000000000000 /* zopfli/zopfli_lib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = zopfli_lib.c; path = zopfli/zopfli_lib.c; sourceTree = SOURCE_ROOT; };
 		5A19439E0FF982D4007C3324 /* libpng.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = libpng.xcodeproj; path = ../libpng/libpng.xcodeproj; sourceTree = SOURCE_ROOT; };
 		5A27BA02139B08A00095FC2F /* release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = release.xcconfig; path = ../imageoptim/release.xcconfig; sourceTree = SOURCE_ROOT; };
 		5A27BA03139B08A00095FC2F /* debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = debug.xcconfig; path = ../imageoptim/debug.xcconfig; sourceTree = SOURCE_ROOT; };
@@ -210,6 +258,30 @@
 				5A81662A0EA117B100962CF2 /* pngex.h */,
 				5A81662B0EA117B100962CF2 /* portable.h */,
 				5A81662D0EA117B100962CF2 /* repng.cc */,
+				AD00FILE0000000000000000 /* portable.c */,
+				AD01FILE0000000000000000 /* libdeflate/arm/cpu_features.c */,
+				AD02FILE0000000000000000 /* libdeflate/x86/cpu_features.c */,
+				AD03FILE0000000000000000 /* libdeflate/adler32.c */,
+				AD04FILE0000000000000000 /* libdeflate/crc32.c */,
+				AD05FILE0000000000000000 /* libdeflate/deflate_compress.c */,
+				AD06FILE0000000000000000 /* libdeflate/deflate_decompress.c */,
+				AD07FILE0000000000000000 /* libdeflate/gzip_compress.c */,
+				AD08FILE0000000000000000 /* libdeflate/gzip_decompress.c */,
+				AD09FILE0000000000000000 /* libdeflate/utils.c */,
+				AD10FILE0000000000000000 /* libdeflate/zlib_compress.c */,
+				AD11FILE0000000000000000 /* libdeflate/zlib_decompress.c */,
+				AD12FILE0000000000000000 /* zopfli/blocksplitter.c */,
+				AD13FILE0000000000000000 /* zopfli/cache.c */,
+				AD14FILE0000000000000000 /* zopfli/deflate.c */,
+				AD15FILE0000000000000000 /* zopfli/gzip_container.c */,
+				AD16FILE0000000000000000 /* zopfli/hash.c */,
+				AD17FILE0000000000000000 /* zopfli/katajainen.c */,
+				AD18FILE0000000000000000 /* zopfli/lz77.c */,
+				AD19FILE0000000000000000 /* zopfli/squeeze.c */,
+				AD20FILE0000000000000000 /* zopfli/tree.c */,
+				AD21FILE0000000000000000 /* zopfli/util.c */,
+				AD22FILE0000000000000000 /* zopfli/zlib_container.c */,
+				AD23FILE0000000000000000 /* zopfli/zopfli_lib.c */,
 				5A81662E0EA117B100962CF2 /* siglock.cc */,
 				5A81662C0EA117B100962CF2 /* siglock.h */,
 				5A8166350EA117B100962CF2 /* snprintf.c */,
@@ -420,6 +492,30 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AD00BUILD000000000000000 /* portable.c in Sources */,
+				AD01BUILD000000000000000 /* libdeflate/arm/cpu_features.c in Sources */,
+				AD02BUILD000000000000000 /* libdeflate/x86/cpu_features.c in Sources */,
+				AD03BUILD000000000000000 /* libdeflate/adler32.c in Sources */,
+				AD04BUILD000000000000000 /* libdeflate/crc32.c in Sources */,
+				AD05BUILD000000000000000 /* libdeflate/deflate_compress.c in Sources */,
+				AD06BUILD000000000000000 /* libdeflate/deflate_decompress.c in Sources */,
+				AD07BUILD000000000000000 /* libdeflate/gzip_compress.c in Sources */,
+				AD08BUILD000000000000000 /* libdeflate/gzip_decompress.c in Sources */,
+				AD09BUILD000000000000000 /* libdeflate/utils.c in Sources */,
+				AD10BUILD000000000000000 /* libdeflate/zlib_compress.c in Sources */,
+				AD11BUILD000000000000000 /* libdeflate/zlib_decompress.c in Sources */,
+				AD12BUILD000000000000000 /* zopfli/blocksplitter.c in Sources */,
+				AD13BUILD000000000000000 /* zopfli/cache.c in Sources */,
+				AD14BUILD000000000000000 /* zopfli/deflate.c in Sources */,
+				AD15BUILD000000000000000 /* zopfli/gzip_container.c in Sources */,
+				AD16BUILD000000000000000 /* zopfli/hash.c in Sources */,
+				AD17BUILD000000000000000 /* zopfli/katajainen.c in Sources */,
+				AD18BUILD000000000000000 /* zopfli/lz77.c in Sources */,
+				AD19BUILD000000000000000 /* zopfli/squeeze.c in Sources */,
+				AD20BUILD000000000000000 /* zopfli/tree.c in Sources */,
+				AD21BUILD000000000000000 /* zopfli/util.c in Sources */,
+				AD22BUILD000000000000000 /* zopfli/zlib_container.c in Sources */,
+				AD23BUILD000000000000000 /* zopfli/zopfli_lib.c in Sources */,
 				5A8166950EA117BB00962CF2 /* 7zdeflate.cc in Sources */,
 				5A8166960EA117BB00962CF2 /* 7zlzma.cc in Sources */,
 				5A8166970EA117BB00962CF2 /* AriBitCoder.cc in Sources */,

--- a/advpng/config.h
+++ b/advpng/config.h
@@ -86,13 +86,16 @@
 #define PACKAGE_NAME "AdvanceCOMP"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "AdvanceCOMP 1.15"
+#define PACKAGE_STRING "AdvanceCOMP 2.6"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "advancecomp"
 
+/* Define to the home page for this package. */
+#define PACKAGE_URL "https://www.advancemame.it"
+
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.15"
+#define PACKAGE_VERSION "2.6"
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
@@ -106,7 +109,7 @@
 #define USE_ERROR_SILENT 1
 
 /* Version number of package */
-#define VERSION "1.15"
+#define VERSION "2.6"
 
 /* Define to empty if `const' does not conform to ANSI C. */
 /* #undef const */

--- a/libpng/Makefile
+++ b/libpng/Makefile
@@ -1,19 +1,30 @@
-VERSION=0.6.5
-OPTIPNG_FILENAME=optipng-$(VERSION).tar.gz
+VERSION=1.6.58
 
 build: all
 
 all: png.h
 
-png.h: /tmp/$(OPTIPNG_FILENAME)
-	tar xzf /tmp/$(OPTIPNG_FILENAME) --strip-components=3 --exclude=Makefile optipng-$(VERSION)/lib/libpng
-	sed -i.bak 's/defined(TARGET_OS_MAC)/0/' pngconf.h && rm pngconf.h.bak
-
-/tmp/$(OPTIPNG_FILENAME):
-	curl -L http://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-$(VERSION)/$(OPTIPNG_FILENAME) -o /tmp/$(OPTIPNG_FILENAME)
+png.h:
+	curl -sL https://github.com/pnggroup/libpng/archive/refs/tags/v$(VERSION).tar.gz | \
+	  tar xz --strip-components=1 --exclude='Makefile*' \
+	    'libpng-$(VERSION)/*.c' 'libpng-$(VERSION)/*.h' \
+	    'libpng-$(VERSION)/arm/*' \
+	    'libpng-$(VERSION)/scripts/pnglibconf.h.prebuilt'
+	# libpng >= 1.5 is configured through pnglibconf.h, not through defines
+	# in config.h. Use the stock configuration...
+	cp scripts/pnglibconf.h.prebuilt pnglibconf.h
+	# ...except that pngcrush calls png_set_option(PNG_IGNORE_ADLER32), which
+	# libpng only declares when built with this option available.
+	sed -i.bak 's|/\*#undef PNG_DISABLE_ADLER32_CHECK_SUPPORTED\*/|#define PNG_DISABLE_ADLER32_CHECK_SUPPORTED|' pnglibconf.h
+	rm -f pnglibconf.h.bak
+	grep -q '^#define PNG_DISABLE_ADLER32_CHECK_SUPPORTED' pnglibconf.h
+	# These carry a main() and are not part of the library.
+	rm -f example.c pngtest.c
 
 clean:
-	test \! -e png.h || rm *.c png.h
+	# config.h is ours and tracked; everything else here is extracted.
+	-rm -rf *.c scripts arm intel loongarch mips powerpc riscv
+	-find . -maxdepth 1 -name '*.h' ! -name config.h -delete
 
 install:
 

--- a/libpng/config.h
+++ b/libpng/config.h
@@ -1,5 +1,11 @@
-/* config.h.  Generated from config.h.in by configure.  */
-/* config.h.in.  Generated from configure.ac by autoheader.  */
+/* Minimal config.h for the libpng+zlib target.
+ *
+ * libpng >= 1.5 takes its feature configuration from pnglibconf.h (we ship
+ * libpng's own scripts/pnglibconf.h.prebuilt), so this file only carries the
+ * autoconf HAVE_* probes that pngpriv.h looks for when HAVE_CONFIG_H is set.
+ * The PNG_*_SUPPORTED defines that used to live here configured libpng 1.4
+ * and have no effect from 1.5 onwards.
+ */
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1
@@ -7,14 +13,8 @@
 /* Define to 1 if you have the <inttypes.h> header file. */
 #define HAVE_INTTYPES_H 1
 
-/* Define to 1 if you have the `m' library (-lm). */
-/* #undef HAVE_LIBM */
-
 /* Define to 1 if you have the `z' library (-lz). */
 #define HAVE_LIBZ 1
-
-/* Define to 1 if you have the <malloc.h> header file. */
-/* #undef HAVE_MALLOC_H */
 
 /* Define to 1 if you have the <memory.h> header file. */
 #define HAVE_MEMORY_H 1
@@ -46,81 +46,12 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #define HAVE_UNISTD_H 1
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
- */
-#define LT_OBJDIR ".libs/"
-
-/* Name of package */
-#define PACKAGE "libpng"
-
-/* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "png-mng-implement@lists.sourceforge.net"
-
-/* Define to the full name of this package. */
-#define PACKAGE_NAME "libpng"
-
-/* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libpng 1.4.5"
-
-/* Define to the one symbol short name of this package. */
-#define PACKAGE_TARNAME "libpng"
-
-/* Define to the home page for this package. */
-#define PACKAGE_URL ""
-
-/* Define to the version of this package. */
-#define PACKAGE_VERSION "1.4.5"
-
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 
-/* Define to 1 if your <sys/time.h> declares `struct tm'. */
-/* #undef TM_IN_SYS_TIME */
-
-/* Version number of package */
-#define VERSION "1.4.5"
-
-/* Define to empty if `const' does not conform to ANSI C. */
-/* #undef const */
-
-/* Define to `unsigned int' if <sys/types.h> does not define. */
-/* #undef size_t */
-
-/* Define to 1 if your <sys/time.h> declares `struct tm'. */
-/* #undef TM_IN_SYS_TIME */
-
-#define PNG_WRITE_SUPPORTED
-#define PNG_USE_LOCAL_ARRAYS
-#define PNG_ALWAYS_EXTERN
-#define PNG_READ_SUPPORTED
-#define PNG_READ_16_TO_8_SUPPORTED
-#define PNG_READ_EXPAND_SUPPORTED
-#define PNG_sBIT_SUPPORTED
-#define PNG_READ_RGB_TO_GRAY_SUPPORTED
-
-#define PNG_NO_FIXED_POINT_SUPPORTED 1
-#define PNG_FLOATING_POINT_SUPPORTED 1
-#define PNG_READ_USER_TRANSFORM_SUPPORTED
-#define PNG_WRITE_TRANSFORMS_NOT_SUPPORTED
-/* Define to empty if `const' does not conform to ANSI C. */
-/* #undef const */
-
-/* Define to `unsigned int' if <sys/types.h> does not define. */
-/* #undef size_t */
-
-#undef PNG_USER_MEM_SUPPORTED /* disables debug malloc in pngcrush; required for optipng compat */
-#ifndef PNG_NO_LEGACY_SUPPORTED
-#  define PNG_NO_LEGACY_SUPPORTED
-#endif
-
-#define PNG_READ_GRAY_TO_RGB_SUPPORTED
-#define PNG_READ_STRIP_ALPHA_SUPPORTED
-#define PNG_READ_FILLER_SUPPORTED
-#define PNG_READ_PACK_SUPPORTED
-#define PNG_READ_SHIFT_SUPPORTED
-#define PNG_SETJMP_SUPPORTED
-
-#define PNG_WRITE_PACK_SUPPORTED
-#define PNG_WRITE_SHIFT_SUPPORTED
-#define PNG_hIST_SUPPORTED
-#define PNG_INFO_IMAGE_SUPPORTED
+/* Name of package */
+#define PACKAGE "libpng"
+#define PACKAGE_NAME "libpng"
+#define PACKAGE_TARNAME "libpng"
+#define PACKAGE_BUGREPORT "png-mng-implement@lists.sourceforge.net"
+#define PACKAGE_URL ""

--- a/libpng/libpng.xcodeproj/project.pbxproj
+++ b/libpng/libpng.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		5A1944080FF98722007C3324 /* pngread.c in Sources */ = {isa = PBXBuildFile; fileRef = 5A1943F60FF98722007C3324 /* pngread.c */; };
 		5A1944090FF98722007C3324 /* pngget.c in Sources */ = {isa = PBXBuildFile; fileRef = 5A1943F70FF98722007C3324 /* pngget.c */; };
 		5A19440B0FF98722007C3324 /* pngwutil.c in Sources */ = {isa = PBXBuildFile; fileRef = 5A1943F90FF98722007C3324 /* pngwutil.c */; };
+		AA2003000000000000000000 /* palette_neon_intrinsics.c in Sources */ = {isa = PBXBuildFile; fileRef = AA0003000000000000000000 /* palette_neon_intrinsics.c */; };
+		AA2002000000000000000000 /* filter_neon_intrinsics.c in Sources */ = {isa = PBXBuildFile; fileRef = AA0002000000000000000000 /* filter_neon_intrinsics.c */; };
+		AA2001000000000000000000 /* arm_init.c in Sources */ = {isa = PBXBuildFile; fileRef = AA0001000000000000000000 /* arm_init.c */; };
 		5A19440C0FF98722007C3324 /* pngrio.c in Sources */ = {isa = PBXBuildFile; fileRef = 5A1943FA0FF98722007C3324 /* pngrio.c */; };
 		5A19440D0FF98722007C3324 /* pngwio.c in Sources */ = {isa = PBXBuildFile; fileRef = 5A1943FB0FF98722007C3324 /* pngwio.c */; };
 		5A19440E0FF98722007C3324 /* pngrutil.c in Sources */ = {isa = PBXBuildFile; fileRef = 5A1943FC0FF98722007C3324 /* pngrutil.c */; };
@@ -49,6 +52,9 @@
 		5AC2B4DF13394F2200376783 /* pngread.c in Sources */ = {isa = PBXBuildFile; fileRef = 5A1943F60FF98722007C3324 /* pngread.c */; };
 		5AC2B4E013394F2200376783 /* pngget.c in Sources */ = {isa = PBXBuildFile; fileRef = 5A1943F70FF98722007C3324 /* pngget.c */; };
 		5AC2B4E213394F2200376783 /* pngwutil.c in Sources */ = {isa = PBXBuildFile; fileRef = 5A1943F90FF98722007C3324 /* pngwutil.c */; };
+		AA1003000000000000000000 /* palette_neon_intrinsics.c in Sources */ = {isa = PBXBuildFile; fileRef = AA0003000000000000000000 /* palette_neon_intrinsics.c */; };
+		AA1002000000000000000000 /* filter_neon_intrinsics.c in Sources */ = {isa = PBXBuildFile; fileRef = AA0002000000000000000000 /* filter_neon_intrinsics.c */; };
+		AA1001000000000000000000 /* arm_init.c in Sources */ = {isa = PBXBuildFile; fileRef = AA0001000000000000000000 /* arm_init.c */; };
 		5AC2B4E313394F2200376783 /* pngrio.c in Sources */ = {isa = PBXBuildFile; fileRef = 5A1943FA0FF98722007C3324 /* pngrio.c */; };
 		5AC2B4E413394F2200376783 /* pngwio.c in Sources */ = {isa = PBXBuildFile; fileRef = 5A1943FB0FF98722007C3324 /* pngwio.c */; };
 		5AC2B4E513394F2200376783 /* pngrutil.c in Sources */ = {isa = PBXBuildFile; fileRef = 5A1943FC0FF98722007C3324 /* pngrutil.c */; };
@@ -123,6 +129,9 @@
 		5A1943F60FF98722007C3324 /* pngread.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pngread.c; sourceTree = "<group>"; };
 		5A1943F70FF98722007C3324 /* pngget.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pngget.c; sourceTree = "<group>"; };
 		5A1943F90FF98722007C3324 /* pngwutil.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pngwutil.c; sourceTree = "<group>"; };
+		AA0003000000000000000000 /* palette_neon_intrinsics.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = palette_neon_intrinsics.c; path = arm/palette_neon_intrinsics.c; sourceTree = "<group>"; };
+		AA0002000000000000000000 /* filter_neon_intrinsics.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = filter_neon_intrinsics.c; path = arm/filter_neon_intrinsics.c; sourceTree = "<group>"; };
+		AA0001000000000000000000 /* arm_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = arm_init.c; path = arm/arm_init.c; sourceTree = "<group>"; };
 		5A1943FA0FF98722007C3324 /* pngrio.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pngrio.c; sourceTree = "<group>"; };
 		5A1943FB0FF98722007C3324 /* pngwio.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pngwio.c; sourceTree = "<group>"; };
 		5A1943FC0FF98722007C3324 /* pngrutil.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pngrutil.c; sourceTree = "<group>"; };
@@ -176,6 +185,9 @@
 				5A1944010FF98722007C3324 /* pngwrite.c */,
 				5A1944040FF98722007C3324 /* pngwtran.c */,
 				5A1943F90FF98722007C3324 /* pngwutil.c */,
+				AA0003000000000000000000 /* palette_neon_intrinsics.c */,
+				AA0002000000000000000000 /* filter_neon_intrinsics.c */,
+				AA0001000000000000000000 /* arm_init.c */,
 			);
 			name = libpng;
 			sourceTree = "<group>";
@@ -357,6 +369,9 @@
 				5AC2B4E913394F2200376783 /* pngwrite.c in Sources */,
 				5AC2B4EC13394F2200376783 /* pngwtran.c in Sources */,
 				5AC2B4E213394F2200376783 /* pngwutil.c in Sources */,
+				AA1003000000000000000000 /* palette_neon_intrinsics.c in Sources */,
+				AA1002000000000000000000 /* filter_neon_intrinsics.c in Sources */,
+				AA1001000000000000000000 /* arm_init.c in Sources */,
 				5ABF907B139400BE0054E027 /* trees.c in Sources */,
 				5ABF907C139400BE0054E027 /* uncompr.c in Sources */,
 				5ABF907D139400BE0054E027 /* zutil.c in Sources */,
@@ -390,6 +405,9 @@
 				5A1944130FF98722007C3324 /* pngwrite.c in Sources */,
 				5A1944160FF98722007C3324 /* pngwtran.c in Sources */,
 				5A19440B0FF98722007C3324 /* pngwutil.c in Sources */,
+				AA2003000000000000000000 /* palette_neon_intrinsics.c in Sources */,
+				AA2002000000000000000000 /* filter_neon_intrinsics.c in Sources */,
+				AA2001000000000000000000 /* arm_init.c in Sources */,
 				5A1941B40FF96FAD007C3324 /* trees.c in Sources */,
 				5A1941B60FF96FAD007C3324 /* uncompr.c in Sources */,
 				5A1941BA0FF96FAD007C3324 /* zutil.c in Sources */,

--- a/pngcrush/Makefile
+++ b/pngcrush/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.8.10
+VERSION=1.8.13
 ARCHIVE=/tmp/pngcrush-$(VERSION).tar.gz
 
 build: all
@@ -6,7 +6,7 @@ build: all
 all: pngcrush.c
 
 $(ARCHIVE):
-	curl -L -o $(ARCHIVE) http://downloads.sourceforge.net/project/pmt/pngcrush/old-versions/1.8/$(VERSION)/pngcrush-$(VERSION).tar.gz
+	curl -L -o $(ARCHIVE) https://downloads.sourceforge.net/project/pmt/pngcrush/$(VERSION)/pngcrush-$(VERSION).tar.gz
 
 tmp/pngcrush.c: pngcrush.patch $(ARCHIVE)
 	test -d tmp || mkdir -p tmp

--- a/pngcrush/pngcrush.patch
+++ b/pngcrush/pngcrush.patch
@@ -1,8 +1,7 @@
 diff --git a/pngcrush.c b/pngcrush.c
-index d0c387e..4f8e107 100644
 --- a/pngcrush.c
 +++ b/pngcrush.c
-@@ -1513,7 +1513,7 @@ static int copy_idat = 0; /* = 1 to simply copy the IDAT chunk data */
+@@ -1513,7 +1513,7 @@
  #endif
  
  #ifndef LIBPNG_UNIFIED
@@ -11,7 +10,7 @@ index d0c387e..4f8e107 100644
  #define PNGCRUSH_TIMER_UINT_API extern unsigned int PNGAPI
  #define PNGCRUSH_TIMER_VOID_API extern void PNGAPI
  #else
-@@ -2295,7 +2295,6 @@ static int overwrite = 0; /* 1: overwrite the input file instead of
+@@ -2295,7 +2295,6 @@
                                  creating a new output file */
  static int nofilecheck = 0;
  static int no_limits = 0;
@@ -19,7 +18,7 @@ index d0c387e..4f8e107 100644
  static png_bytep row_buf;
  #ifdef PNGCRUSH_MULTIPLE_ROWS
  static png_bytepp row_pointers;
-@@ -2845,7 +2844,6 @@ void pngcrush_pause(void)
+@@ -2845,7 +2844,6 @@
          char keystroke;
          fprintf(STDERR, "Press [ENTER] key to continue.\n");
          keystroke = (char) getc(stdin);
@@ -27,7 +26,7 @@ index d0c387e..4f8e107 100644
      }
  }
  
-@@ -3234,7 +3232,6 @@ void pngcrush_write_png(png_structp write_pointer, png_bytep data,
+@@ -3234,7 +3232,6 @@
  static void pngcrush_flush(png_structp png_ptr)
  {
     /* Do nothing. */
@@ -35,7 +34,7 @@ index d0c387e..4f8e107 100644
  }
  
  
-@@ -3287,6 +3284,7 @@ void pngcrush_examine_pixels_fn(png_structp png_ptr, png_row_infop
+@@ -3287,6 +3284,7 @@
        if ((row_info->color_type == 2 || row_info->color_type == 6) &&
            make_gray == 1) /* RGB */
        {
@@ -43,7 +42,7 @@ index d0c387e..4f8e107 100644
          if (row_info->bit_depth == 8)
            {
              int incr=3;
-@@ -3372,6 +3370,7 @@ void pngcrush_examine_pixels_fn(png_structp png_ptr, png_row_infop
+@@ -3372,6 +3370,7 @@
                 make_opaque == 1))
        {
          i = (int) row_info->rowbytes-1;
@@ -51,7 +50,42 @@ index d0c387e..4f8e107 100644
  
          if (row_info->bit_depth == 8)
            {
-@@ -8343,7 +8342,7 @@ png_uint_32 pngcrush_measure_idat(png_structp png_ptr)
+@@ -4084,7 +4083,6 @@
+             names++;
+             BUMP_I;
+             mngname = argv[i];
+-            new_mng++;
+         }
+ #endif
+ 
+@@ -4828,7 +4826,7 @@
+             number_of_open_files++;
+ 
+ #ifdef PNGCRUSH_LOCO
+-            if (new_mng)
++            if (0)
+             {
+ 
+ #  ifdef PNG_USER_MEM_SUPPORTED
+@@ -4866,7 +4864,7 @@
+             idat_length[0] = measure_idats(fpin);
+ 
+ #ifdef PNGCRUSH_LOCO
+-            if (new_mng)
++            if (0)
+             {
+                     png_destroy_write_struct(&mng_ptr, NULL);
+                     FCLOSE(mng_out);
+@@ -8243,7 +8241,7 @@
+                 (unsigned long) pngcrush_get_uint_31(png_ptr,&buff[24]));
+             }
+ 
+-            if (new_mng)
++            if (0)
+             {
+                 /* write the MNG 8-byte signature */
+                 pngcrush_write_png(mng_ptr, &mng_signature[0],
+@@ -8343,7 +8341,7 @@
                printf("   Reading %c%c%c%c chunk.\n",
                    chunk_name[0],chunk_name[1],chunk_name[2],chunk_name[3]);
  
@@ -60,7 +94,7 @@ index d0c387e..4f8e107 100644
          {
            const png_byte png_DHDR[5] = {  68, 72, 68, 82, '\0' };
            const png_byte png_DEFI[5] = {  68, 69, 70, 73, '\0' };
-@@ -8653,7 +8652,7 @@ png_uint_32 pngcrush_measure_idat(png_structp png_ptr)
+@@ -8653,7 +8651,7 @@
                  { 77, 69, 78, 68, '\0' };
              if (!png_memcmp(chunk_name, png_MEND, 4))
              {
@@ -69,7 +103,7 @@ index d0c387e..4f8e107 100644
                  {
                      png_free(mng_ptr,bb);
                      return (0);
-@@ -8736,6 +8735,7 @@ void print_version_info(void)
+@@ -8736,6 +8734,7 @@
         * immediately after this sentence: */
        " |    Copyright (C) 1998-2002, 2006-2017 Glenn Randers-Pehrson\n"
        " |    Portions Copyright (C) 2005 Greg Roelofs\n"

--- a/zlib/Makefile
+++ b/zlib/Makefile
@@ -1,16 +1,19 @@
 
 # zlib is not built here! It's included as part of libpng instead.
 
-VERSION=0.7.7
+VERSION=1.3.2
 
 build: all
 
 all: zlib.h
 
 zlib.h:
-	curl -L http://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-$(VERSION)/optipng-$(VERSION).tar.gz | tar xz --strip-components=3 --exclude=Makefile optipng-$(VERSION)/src/zlib
+	curl -sL https://github.com/madler/zlib/archive/refs/tags/v$(VERSION).tar.gz | \
+	  tar xz --strip-components=1 --exclude='Makefile*' \
+	    'zlib-$(VERSION)/*.c' 'zlib-$(VERSION)/*.h'
 
 clean:
+	-rm -f *.c *.h
 
 install:
 


### PR DESCRIPTION
`liblibpng.dylib` ships in the app and parses whatever the user drops on it, so libpng and zlib are reachable from untrusted input. Both are currently very old, and both are vendored indirectly out of OptiPNG release tarballs:

| | before | after |
|---|---|---|
| libpng | 1.4.5-optipng (December 2010), from `optipng-0.6.5.tar.gz` | **1.6.58** |
| zlib | 1.2.11-optipng, from `optipng-0.7.7.tar.gz` | **1.3.2** |
| pngcrush | 1.8.10 | **1.8.13** |
| advancecomp | 1.15, from a 2012 Debian snapshot | **2.6** |

zlib 1.2.11 predates the 1.2.12 security release; libpng 1.4.5 predates a long list of fixes. Both are now fetched from their own upstreams rather than via OptiPNG.

The `-optipng` patch that came with libpng turned out to be 30 lines and purely cosmetic — a version string, `PNG_USER_CONFIG`, and a `pngusr.h` — so nothing is lost by dropping it. The `.c` file lists are unchanged between libpng 1.4 and 1.6 and between the old and new zlib, which kept the project churn small.

### Things worth knowing during review

- **libpng ≥1.5 is configured through `pnglibconf.h`**, not through `PNG_*_SUPPORTED` defines in `config.h`. This ships libpng's own `scripts/pnglibconf.h.prebuilt` and strips the now-inert defines from `config.h`.
- **pngcrush 1.8.13 requires libpng 1.6**: it calls `png_set_option(PNG_IGNORE_ADLER32)`, and `png_set_option` did not exist in 1.4. That is why it moves in the same commit rather than separately. `PNG_IGNORE_ADLER32` is only declared when libpng is built with `PNG_DISABLE_ADLER32_CHECK_SUPPORTED`, so the Makefile enables it in the generated `pnglibconf.h`.
- **The pngcrush patch is regenerated against 1.8.13.** Its intent is unchanged (MNG output stays disabled); 1.8.13 simply has four `new_mng` references the 1.8.10 patch did not cover.
- **libpng 1.6 has ARM NEON filter implementations, on by default on arm64.** `arm/arm_init.c`, `arm/filter_neon_intrinsics.c` and `arm/palette_neon_intrinsics.c` are added to both libpng targets; without them the build fails to link.
- **advancecomp 2.6** replaces the old 7z-only deflate path with libdeflate and zopfli backends, so 24 sources are added to the advpng target. The existing group layout already matches 2.6's directory structure. `config.h` needed `PACKAGE_URL` (2.6 prints it in `--version`).
- Note that bsdtar's `*` matches across `/`, so the libpng extraction also picks up the `intel/`, `mips/`, `powerpc/`, `riscv/` and `loongarch/` directories. Harmless — only the listed files are compiled — but `clean` and `.gitignore` cover them.

### Verification

Built on macOS 27 / Xcode 27, then round-tripped an 11-image corpus through the app — RGB8, RGBA8, gray8, gray16, 64-colour palette, interlaced, 1×1, fully transparent, flat-colour, JPEG, GIF. **Every file comes out pixel-identical to its original**, with savings from 11% to 87% on the non-degenerate ones.

One result that looks alarming and is not: on photographic images advpng reports `(Bigger 168645)` and keeps the original. advpng discards PNG filters, so its recompression of a photo is necessarily much larger. A reference build of advancecomp 2.6 configured with its own autotools produces a **byte-identical** 168645 on the same input, which is what confirms the Xcode integration is faithful. On the flat-colour and palette images advpng is actually meant for, it saves 3–12%.

### Compression ratios, before vs after

Measured by building the branch point and this branch separately and running the same 12-image corpus through both apps. Everything below is lossless — every output is pixel-identical to its input in both builds.

**At tool level the new versions are equal or better, never worse:**

| tool | image | before | after | |
|---|---|---:|---:|---|
| pngcrush | rgb8.png | 9010 | **7974** | −11.5% |
| pngcrush | gray8.png | 13329 | **13189** | −1.1% |
| pngcrush | screenshot.png | 935 | **934** | −1 byte |
| pngcrush | palette64.png, flat.png | | | unchanged |
| advpng | screenshot.png | 627 | **579** | −7.7% |
| advpng | palette64.png | 12182 | **12133** | −0.4% |
| advpng | rgb8.png, flat.png, gray8.png | | | unchanged |

**At app level there is no difference at all**: all 12 files come out byte-identical, total savings 18.92% either way. That is expected — ImageOptim keeps the smallest result across all optimizers, and zopfli/oxipng/pngout already win on this corpus, so the pngcrush and advpng gains never surface. So: no regression, and no user-visible change either.

Two things worth knowing if you want to reproduce this, because both silently invalidate the measurement:

- `~/Library/Caches/net.pornel.ImageOptim/Results.db` caches "unoptimizable" verdicts by content hash, so it has to be deleted between runs or the second run skips files.
- pngcrush and advpng are the *only* consumers of the changed libpng and zlib, and `PngCrush2Enabled` defaults to false. With stock settings this comparison measures nothing; both have to be enabled explicitly.

Related: #467 (deployment target) and #469 (pngout codesign) both block a from-scratch build on a machine without upstream's certificates; neither is required for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

