### PR TITLE
Add lossless WebP recompression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,11 @@ svgo/build/
 svgo/node_modules/
 pngcrush/tmp/
 pngcrush/LICENSE
+libwebp/build
+libwebp/CompilationCache.noindex
+libwebp/DerivedData
+libwebp/COPYING
+libwebp/examples
+libwebp/imageio
+libwebp/sharpyuv
+libwebp/src

--- a/imageoptim/Backend/File.h
+++ b/imageoptim/Backend/File.h
@@ -15,6 +15,10 @@ enum IOFileType {
     FILETYPE_JPEG,
     FILETYPE_GIF,
     FILETYPE_SVG,
+    // Only losslessly-compressed WebP. Lossy WebP can't be recompressed
+    // without further quality loss, and there is only one WebP encoder,
+    // so such files are not accepted at all.
+    FILETYPE_WEBP_LOSSLESS,
 };
 
 NS_ASSUME_NONNULL_BEGIN

--- a/imageoptim/Backend/File.m
+++ b/imageoptim/Backend/File.m
@@ -26,6 +26,55 @@
     return self;
 }
 
+/// A WebP file is a RIFF container. Only a still, losslessly-compressed image
+/// (a VP8L chunk) can be recompressed without losing quality: there is just one
+/// WebP encoder, so re-encoding a lossy VP8 bitstream would degrade it, and an
+/// animation (ANIM) can't be handled by cwebp at all. Both are rejected here.
+///
+/// A plain lossless file has VP8L right after the header, but a file with an
+/// alpha channel, ICC profile or EXIF is wrapped in an extended (VP8X) header,
+/// so the chunks have to be walked to find out.
+static BOOL IsLosslessWebP(NSData *fileData) {
+    const NSUInteger length = fileData.length;
+    if (length < 12) {
+        return NO;
+    }
+
+    unsigned char header[12];
+    [fileData getBytes:header length:sizeof(header)];
+
+    if (0 != memcmp(header, "RIFF", 4) || 0 != memcmp(header + 8, "WEBP", 4)) {
+        return NO;
+    }
+
+    // Walk the chunk list. A plain lossless file has VP8L first; one with an
+    // alpha channel, ICC profile or EXIF starts with an extended VP8X header
+    // and VP8L follows further in. Chunks are an 8-byte header plus a payload
+    // padded to an even length. The iteration cap bounds the work a malformed
+    // file full of tiny chunks could cause.
+    NSUInteger offset = 12;
+    for (int i = 0; i < 64 && offset + 8 <= length; i++) {
+        unsigned char chunk[8];
+        [fileData getBytes:chunk range:NSMakeRange(offset, sizeof(chunk))];
+
+        if (0 == memcmp(chunk, "VP8L", 4)) {
+            return YES;
+        }
+        if (0 == memcmp(chunk, "VP8 ", 4) || 0 == memcmp(chunk, "ANIM", 4)) {
+            return NO;
+        }
+
+        const uint32_t payload = (uint32_t)chunk[4] | ((uint32_t)chunk[5] << 8) |
+                                 ((uint32_t)chunk[6] << 16) | ((uint32_t)chunk[7] << 24);
+        const NSUInteger step = 8 + (NSUInteger)payload + (payload & 1);
+        if (step <= 8 || step > length - offset) {
+            return NO; // truncated or malformed
+        }
+        offset += step;
+    }
+    return NO;
+}
+
 -(instancetype)initWithData:(NSData *)fileData fromPath:(NSURL *)aPath {
     const unsigned char pngheader[] = {0x89,0x50,0x4e,0x47,0x0d,0x0a};
     const unsigned char jpegheader[] = {0xff,0xd8,0xff};
@@ -49,6 +98,8 @@
         type = FILETYPE_GIF;
     } else if (0 == memcmp(fileHeaderBytes, svgheader, sizeof(svgheader)) || [aPath.pathExtension isEqualToString:@"svg"]) {
         type = FILETYPE_SVG;
+    } else if (IsLosslessWebP(fileData)) {
+        type = FILETYPE_WEBP_LOSSLESS;
     }
 
     return [self initWithType:type size:fileData.length fromPath:aPath];
@@ -108,6 +159,7 @@
         case FILETYPE_JPEG: return @"image/jpeg";
         case FILETYPE_GIF: return @"image/gif";
         case FILETYPE_SVG: return @"image/svg";
+        case FILETYPE_WEBP_LOSSLESS: return @"image/webp";
         default:
             return nil;
     }

--- a/imageoptim/Backend/Job.m
+++ b/imageoptim/Backend/Job.m
@@ -17,6 +17,7 @@
 #import "Workers/GifsicleWorker.h"
 #import "Workers/SvgoWorker.h"
 #import "Workers/SvgcleanerWorker.h"
+#import "Workers/WebpWorker.h"
 #import "Workers/GuetzliWorker.h"
 #import <sys/xattr.h>
 #import "log.h"
@@ -636,6 +637,13 @@
             }
         }
         break;
+        case FILETYPE_WEBP_LOSSLESS:
+            if ([defs boolForKey:@"WebPEnabled"]) {
+                [worker_list addObject:[[WebpWorker alloc] initWithLevel:level
+                                                          stripMetadata:[defs boolForKey:@"PngOutRemoveChunks"]
+                                                                   file:self]];
+            }
+            break;
         case FILETYPE_SVG:
             if ([defs boolForKey:@"SvgoEnabled"]) {
                 [worker_list addObject:[[SvgoWorker alloc] initWithLossy:lossyEnabled job:self]];

--- a/imageoptim/Backend/Workers/WebpWorker.h
+++ b/imageoptim/Backend/Workers/WebpWorker.h
@@ -1,0 +1,16 @@
+//
+//  WebpWorker.h
+//
+//  Recompresses losslessly-compressed WebP images with a higher effort setting.
+//
+
+@import Cocoa;
+#import "CommandWorker.h"
+
+@interface WebpWorker : CommandWorker {
+    NSInteger effort;
+    BOOL strip;
+}
+
+- (instancetype)initWithLevel:(NSInteger)level stripMetadata:(BOOL)aStrip file:(Job *)aFile;
+@end

--- a/imageoptim/Backend/Workers/WebpWorker.m
+++ b/imageoptim/Backend/Workers/WebpWorker.m
@@ -1,0 +1,73 @@
+//
+//  WebpWorker.m
+//
+//  Recompresses losslessly-compressed WebP images with a higher effort setting.
+//
+//  There is only one WebP encoder, so unlike PNG there is no second tool to
+//  compete with. The gain comes purely from cwebp's -z level: most WebP files
+//  in the wild were written at the default effort, and re-encoding them at the
+//  maximum is lossless but noticeably smaller. Files that were already written
+//  at a high effort barely shrink, which is fine — the result is only kept if
+//  it is smaller.
+//
+//  Job.m only ever hands us files detected as FILETYPE_WEBP_LOSSLESS, so a
+//  lossy bitstream can never reach this worker.
+//
+
+#import "WebpWorker.h"
+#import "../Job.h"
+#import "../TempFile.h"
+
+@implementation WebpWorker
+
+- (instancetype)initWithLevel:(NSInteger)level stripMetadata:(BOOL)aStrip file:(Job *)aJob {
+    if (self = [super initWithFile:aJob]) {
+        // cwebp's -z goes 0..9. The default it was probably written with is 6,
+        // so anything below that would be pointless.
+        effort = MAX(7, MIN(level + 5, 9));
+        strip = aStrip;
+    }
+    return self;
+}
+
+- (NSInteger)settingsIdentifier {
+    return effort * 2 + strip;
+}
+
+- (BOOL)optimizeFile:(File *)file toTempPath:(NSURL *)temp {
+    // "-o" has to come before "--": cwebp treats the argument after "--" as
+    // the input file and stops parsing, so a trailing "-o" would be swallowed
+    // and it would exit 0 without writing anything.
+    NSArray *args = @[ @"-quiet",
+                       @"-lossless",
+                       // Without this cwebp zeroes the RGB channels of fully
+                       // transparent pixels. That is invisible when composited,
+                       // but it destroys data in images that pack information
+                       // under the alpha mask, so it is not lossless in the
+                       // sense this tool promises.
+                       @"-exact",
+                       @"-z", [NSString stringWithFormat:@"%d", (int)effort],
+                       @"-metadata", strip ? @"none" : @"all",
+                       @"-o", temp.path,
+                       @"--", file.path ];
+
+    if (![self taskForKey:@"Webp" bundleName:@"cwebp" arguments:args]) {
+        return NO;
+    }
+
+    NSFileHandle *devnull = [NSFileHandle fileHandleWithNullDevice];
+
+    [task setStandardInput:devnull];
+    [task setStandardError:devnull];
+    [task setStandardOutput:devnull];
+
+    [self launchTask];
+
+    BOOL ok = [self waitUntilTaskExit];
+
+    if (!ok) return NO;
+
+    return [job setFileOptimized:[file tempCopyOfPath:temp] toolName:@"WebP"];
+}
+
+@end

--- a/imageoptim/FilesController.m
+++ b/imageoptim/FilesController.m
@@ -461,6 +461,7 @@ static NSString *kIMDraggedRowIndexesPboardType = @"com.imageoptim.rows";
 #define JPEG_ENABLED 2
 #define GIF_ENABLED 4
 #define SVG_ENABLED 8
+#define WEBP_ENABLED 16
 
 - (int)typesEnabled {
     int types = 0;
@@ -481,6 +482,10 @@ static NSString *kIMDraggedRowIndexesPboardType = @"com.imageoptim.rows";
 
     if ([defs boolForKey:@"SvgoEnabled"] || [defs boolForKey:@"SvgcleanerEnabled"]) {
         types |= SVG_ENABLED;
+    }
+
+    if ([defs boolForKey:@"WebPEnabled"]) {
+        types |= WEBP_ENABLED;
     }
 
     if (!types) types = PNG_ENABLED; // will show error in the list
@@ -505,6 +510,9 @@ static NSString *kIMDraggedRowIndexesPboardType = @"com.imageoptim.rows";
     if (types & SVG_ENABLED) {
         [extensions addObject:@"svg"];
     }
+    if (types & WEBP_ENABLED) {
+        [extensions addObjectsFromArray:@[ @"webp", @"WEBP" ]];
+    }
 
     return extensions;
 }
@@ -525,6 +533,9 @@ static NSString *kIMDraggedRowIndexesPboardType = @"com.imageoptim.rows";
     }
     if (types & SVG_ENABLED) {
         [fileTypes addObjectsFromArray:@[ @"svg", @"public.svg-image", @"image/svg" ]];
+    }
+    if (types & WEBP_ENABLED) {
+        [fileTypes addObjectsFromArray:@[ @"webp", @"WEBP", @"org.webmproject.webp", @"image/webp" ]];
     }
     return fileTypes;
 }

--- a/imageoptim/ImageOptim.xcodeproj/project.pbxproj
+++ b/imageoptim/ImageOptim.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		5A7FB6F31E2C37EB00481B4A /* SvgoWorker.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A7FB6F21E2C37EB00481B4A /* SvgoWorker.m */; };
 		5A7FB7261E2C3E1600481B4A /* svgo.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5A7FB7251E2C3E1600481B4A /* svgo.js */; };
 		5A93FD2F1FF1C452005D2F27 /* SvgcleanerWorker.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A93FD051FF1BF1F005D2F27 /* SvgcleanerWorker.m */; };
+		WEBPXWORKERMB00000000000 /* WebpWorker.m in Sources */ = {isa = PBXBuildFile; fileRef = WEBPXWORKERM000000000000 /* WebpWorker.m */; };
 		5A99FE84140AE80600BB2F79 /* Quartz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A99FE83140AE80600BB2F79 /* Quartz.framework */; };
 		5AA1B7E9140AC55F00B5707C /* RevealButtonCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A391880140A9B10001B4FD7 /* RevealButtonCell.m */; };
 		5AACA8310CAFE74E004D45CA /* Transformers.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AACA8300CAFE74E004D45CA /* Transformers.m */; };
@@ -97,6 +98,7 @@
 		5FD569DD21A059A000BC9F82 /* JobProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FD569DC21A059A000BC9F82 /* JobProxy.m */; };
 		5FFC96C1275842310035D0A2 /* oxipng in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5F75B47527583B9B0072F27A /* oxipng */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		5FFC9752275843210035D0A2 /* svgcleaner in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5FFC9750275843160035D0A2 /* svgcleaner */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		WEBPXCOPYFILE00000000000 /* cwebp in CopyFiles */ = {isa = PBXBuildFile; fileRef = WEBPXREFPROXY00000000000 /* cwebp */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
 		D047E4651E7C3D7C0036F96B /* GuetzliWorker.m in Sources */ = {isa = PBXBuildFile; fileRef = D047E4641E7C3D7C0036F96B /* GuetzliWorker.m */; };
 		D047E5311E7D90DD0036F96B /* guetzli in CopyFiles */ = {isa = PBXBuildFile; fileRef = D047E4861E7D7E310036F96B /* guetzli */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -390,6 +392,20 @@
 			remoteGlobalIDString = CA6070D14537821B170C4A65;
 			remoteInfo = "svgcleaner-bin";
 		};
+		WEBPXPROXY20000000000000 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = WEBPXPROJREF000000000000 /* libwebp.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = WEBP0000000000000000PREF;
+			remoteInfo = cwebp;
+		};
+		WEBPXPROXY10000000000000 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = WEBPXPROJREF000000000000 /* libwebp.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = WEBP0000000000000000TOOL;
+			remoteInfo = cwebp;
+		};
 		5FFC9753275843280035D0A2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 5A93FB491FF1BB2C005D2F27 /* svgcleaner.xcodeproj */;
@@ -446,6 +462,7 @@
 				5ABE15841AE5074900861C6B /* pngout in CopyFiles */,
 				5F91633A2ADB7A7B00230D34 /* pngquant in CopyFiles */,
 				5FFC9752275843210035D0A2 /* svgcleaner in CopyFiles */,
+				WEBPXCOPYFILE00000000000 /* cwebp in CopyFiles */,
 				5A7FB7261E2C3E1600481B4A /* svgo.js in CopyFiles */,
 				5ABE162A1AE5099F00861C6B /* zopflipng in CopyFiles */,
 			);
@@ -617,8 +634,11 @@
 		5A8DFBD910C097B9009A5C8E /* Dutch */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Dutch; path = nl.lproj/Help; sourceTree = "<group>"; };
 		5A8DFBEB10C09812009A5C8E /* Dutch */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Dutch; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		5A93FB491FF1BB2C005D2F27 /* svgcleaner.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = svgcleaner.xcodeproj; path = ../svgcleaner/svgcleaner.xcodeproj; sourceTree = "<group>"; };
+		WEBPXPROJREF000000000000 /* libwebp.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = libwebp.xcodeproj; path = ../libwebp/libwebp.xcodeproj; sourceTree = "<group>"; };
 		5A93FCEC1FF1BF1F005D2F27 /* SvgcleanerWorker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SvgcleanerWorker.h; sourceTree = "<group>"; };
 		5A93FD051FF1BF1F005D2F27 /* SvgcleanerWorker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SvgcleanerWorker.m; sourceTree = "<group>"; };
+		WEBPXWORKERH000000000000 /* WebpWorker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebpWorker.h; sourceTree = "<group>"; };
+		WEBPXWORKERM000000000000 /* WebpWorker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WebpWorker.m; sourceTree = "<group>"; };
 		5A94A00C102757E5005CC9CB /* French */ = {isa = PBXFileReference; lastKnownFileType = file.plist.strings; name = French; path = fr.lproj/PrefsController.strings; sourceTree = "<group>"; };
 		5A94A00D102757F0005CC9CB /* French */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = French; path = fr.lproj/ImageOptim.strings; sourceTree = "<group>"; };
 		5A94A02610275AFD005CC9CB /* fr */ = {isa = PBXFileReference; lastKnownFileType = folder; name = fr; path = fr.lproj/Help; sourceTree = "<group>"; };
@@ -780,6 +800,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		WEBPXPRODGRP000000000000 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				WEBPXREFPROXY00000000000 /* cwebp */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		080E96DDFE201D6D7F000001 /* Backend */ = {
 			isa = PBXGroup;
 			children = (
@@ -857,6 +885,7 @@
 				5A728F191836C0EE004D0D73 /* pngquant.xcodeproj */,
 				5A27B956139B03090095FC2F /* release.xcconfig */,
 				5A93FB491FF1BB2C005D2F27 /* svgcleaner.xcodeproj */,
+				WEBPXPROJREF000000000000 /* libwebp.xcodeproj */,
 				5A1EBE7617908DC300361F08 /* zopfli-png.xcodeproj */,
 			);
 			name = "Other Sources";
@@ -1116,6 +1145,8 @@
 				5AB81F941AE1BE1300719AB7 /* Save.m */,
 				5A93FCEC1FF1BF1F005D2F27 /* SvgcleanerWorker.h */,
 				5A93FD051FF1BF1F005D2F27 /* SvgcleanerWorker.m */,
+				WEBPXWORKERH000000000000 /* WebpWorker.h */,
+				WEBPXWORKERM000000000000 /* WebpWorker.m */,
 				5A7FB6D61E2C37DD00481B4A /* SvgoWorker.h */,
 				5A7FB6F21E2C37EB00481B4A /* SvgoWorker.m */,
 				5AACA13D0CAF241B004D45CA /* Worker.h */,
@@ -1205,6 +1236,7 @@
 			);
 			dependencies = (
 				5A7FB7241E2C3DF800481B4A /* PBXTargetDependency */,
+				WEBPXTARGDEP000000000000 /* PBXTargetDependency */,
 				5AB114B11B52AEE700A3C73A /* PBXTargetDependency */,
 				5ABE16061AE5089300861C6B /* PBXTargetDependency */,
 				5ABE16081AE5089700861C6B /* PBXTargetDependency */,
@@ -1404,6 +1436,10 @@
 					ProjectRef = 5A93FB491FF1BB2C005D2F27 /* svgcleaner.xcodeproj */;
 				},
 				{
+					ProductGroup = WEBPXPRODGRP000000000000 /* Products */;
+					ProjectRef = WEBPXPROJREF000000000000 /* libwebp.xcodeproj */;
+				},
+				{
 					ProductGroup = 5A1EBECF17908F8200361F08 /* Products */;
 					ProjectRef = 5A1EBE7617908DC300361F08 /* zopfli-png.xcodeproj */;
 				},
@@ -1575,6 +1611,13 @@
 			remoteRef = 5FFC974F275843160035D0A2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		WEBPXREFPROXY00000000000 /* cwebp */ = {
+			isa = PBXReferenceProxy;
+			fileType = "compiled.mach-o.executable";
+			path = cwebp;
+			remoteRef = WEBPXPROXY20000000000000 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		D047E4601E7C3CE80036F96B /* fileop */ = {
 			isa = PBXReferenceProxy;
 			fileType = "compiled.mach-o.executable";
@@ -1671,6 +1714,7 @@
 				5AC4CC801AF568E90003AEA2 /* SavingsFormatter.m in Sources */,
 				5A6A56D01B497E210045AA0C /* SharedPrefs.m in Sources */,
 				5A93FD2F1FF1C452005D2F27 /* SvgcleanerWorker.m in Sources */,
+				WEBPXWORKERMB00000000000 /* WebpWorker.m in Sources */,
 				5A7FB6F31E2C37EB00481B4A /* SvgoWorker.m in Sources */,
 				5AD0347D1E27185D0030291A /* TempFile.m in Sources */,
 				5ABE15821AE5073E00861C6B /* Worker.m in Sources */,
@@ -1814,6 +1858,11 @@
 			isa = PBXTargetDependency;
 			name = "svgcleaner-bin";
 			targetProxy = 5FFC9753275843280035D0A2 /* PBXContainerItemProxy */;
+		};
+		WEBPXTARGDEP000000000000 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = cwebp;
+			targetProxy = WEBPXPROXY10000000000000 /* PBXContainerItemProxy */;
 		};
 		D047E4CD1E7D81040036F96B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/imageoptim/Info.plist
+++ b/imageoptim/Info.plist
@@ -80,6 +80,29 @@
 		<dict>
 			<key>CFBundleTypeExtensions</key>
 			<array>
+				<string>webp</string>
+				<string>WEBP</string>
+			</array>
+			<key>CFBundleTypeMIMETypes</key>
+			<array>
+				<string>image/webp</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>WebP</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.webmproject.webp</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+			<key>NSPersistentStoreTypeKey</key>
+			<string>Binary</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
 				<string>jpeg</string>
 				<string>jpg</string>
 				<string>JPG</string>
@@ -173,6 +196,7 @@
 				<string>public.jpeg</string>
 				<string>com.compuserve.gif</string>
 				<string>public.svg-image</string>
+				<string>org.webmproject.webp</string>
 			</array>
 			<key>NSServiceDescription</key>
 			<string>Losslessly reduce image file sizes with ImageOptim</string>

--- a/imageoptim/defaults.plist
+++ b/imageoptim/defaults.plist
@@ -28,6 +28,8 @@
 	<true/>
 	<key>SvgcleanerEnabled</key>
 	<true/>
+	<key>WebPEnabled</key>
+	<true/>
 	<key>ZopfliEnabled</key>
 	<true/>
 	<key>GifsicleEnabled</key>

--- a/libwebp/Makefile
+++ b/libwebp/Makefile
@@ -1,0 +1,19 @@
+VERSION=1.6.0
+
+build: all
+
+all: src/webp/encode.h
+
+src/webp/encode.h:
+	curl -sL https://github.com/webmproject/libwebp/archive/refs/tags/v$(VERSION).tar.gz | \
+	  tar xz --strip-components=1 --exclude='Makefile*' \
+	    'libwebp-$(VERSION)/src' 'libwebp-$(VERSION)/sharpyuv' \
+	    'libwebp-$(VERSION)/imageio' \
+	    'libwebp-$(VERSION)/examples' 'libwebp-$(VERSION)/COPYING'
+
+clean:
+	-rm -rf src sharpyuv imageio examples COPYING
+
+install:
+
+.PHONY: build all install clean

--- a/libwebp/libwebp.xcodeproj/project.pbxproj
+++ b/libwebp/libwebp.xcodeproj/project.pbxproj
@@ -1,0 +1,765 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+
+/* Begin PBXBuildFile section */
+		WEBB00000000000000000000 /* cwebp.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000000000 /* cwebp.c */; };
+		WEBB00000000000000000100 /* example_util.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000000100 /* example_util.c */; };
+		WEBB00000000000000000200 /* image_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000000200 /* image_dec.c */; };
+		WEBB00000000000000000300 /* imageio_util.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000000300 /* imageio_util.c */; };
+		WEBB00000000000000000400 /* jpegdec.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000000400 /* jpegdec.c */; };
+		WEBB00000000000000000500 /* metadata.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000000500 /* metadata.c */; };
+		WEBB00000000000000000600 /* pngdec.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000000600 /* pngdec.c */; };
+		WEBB00000000000000000700 /* pnmdec.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000000700 /* pnmdec.c */; };
+		WEBB00000000000000000800 /* tiffdec.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000000800 /* tiffdec.c */; };
+		WEBB00000000000000000900 /* webpdec.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000000900 /* webpdec.c */; };
+		WEBB00000000000000000A00 /* sharpyuv.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000000A00 /* sharpyuv.c */; };
+		WEBB00000000000000000B00 /* sharpyuv_cpu.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000000B00 /* sharpyuv_cpu.c */; };
+		WEBB00000000000000000C00 /* sharpyuv_csp.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000000C00 /* sharpyuv_csp.c */; };
+		WEBB00000000000000000D00 /* sharpyuv_dsp.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000000D00 /* sharpyuv_dsp.c */; };
+		WEBB00000000000000000E00 /* sharpyuv_gamma.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000000E00 /* sharpyuv_gamma.c */; };
+		WEBB00000000000000000F00 /* sharpyuv_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000000F00 /* sharpyuv_neon.c */; };
+		WEBB00000000000000001000 /* sharpyuv_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000001000 /* sharpyuv_sse2.c */; };
+		WEBB00000000000000001100 /* alpha_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000001100 /* alpha_dec.c */; };
+		WEBB00000000000000001200 /* buffer_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000001200 /* buffer_dec.c */; };
+		WEBB00000000000000001300 /* frame_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000001300 /* frame_dec.c */; };
+		WEBB00000000000000001400 /* idec_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000001400 /* idec_dec.c */; };
+		WEBB00000000000000001500 /* io_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000001500 /* io_dec.c */; };
+		WEBB00000000000000001600 /* quant_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000001600 /* quant_dec.c */; };
+		WEBB00000000000000001700 /* tree_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000001700 /* tree_dec.c */; };
+		WEBB00000000000000001800 /* vp8_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000001800 /* vp8_dec.c */; };
+		WEBB00000000000000001900 /* vp8l_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000001900 /* vp8l_dec.c */; };
+		WEBB00000000000000001A00 /* webp_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000001A00 /* webp_dec.c */; };
+		WEBB00000000000000001B00 /* anim_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000001B00 /* anim_decode.c */; };
+		WEBB00000000000000001C00 /* demux.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000001C00 /* demux.c */; };
+		WEBB00000000000000001D00 /* alpha_processing.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000001D00 /* alpha_processing.c */; };
+		WEBB00000000000000001E00 /* alpha_processing_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000001E00 /* alpha_processing_mips_dsp_r2.c */; };
+		WEBB00000000000000001F00 /* alpha_processing_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000001F00 /* alpha_processing_neon.c */; };
+		WEBB00000000000000002000 /* alpha_processing_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000002000 /* alpha_processing_sse2.c */; };
+		WEBB00000000000000002100 /* alpha_processing_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000002100 /* alpha_processing_sse41.c */; };
+		WEBB00000000000000002200 /* cost.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000002200 /* cost.c */; };
+		WEBB00000000000000002300 /* cost_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000002300 /* cost_mips32.c */; };
+		WEBB00000000000000002400 /* cost_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000002400 /* cost_mips_dsp_r2.c */; };
+		WEBB00000000000000002500 /* cost_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000002500 /* cost_neon.c */; };
+		WEBB00000000000000002600 /* cost_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000002600 /* cost_sse2.c */; };
+		WEBB00000000000000002700 /* cpu.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000002700 /* cpu.c */; };
+		WEBB00000000000000002800 /* dec.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000002800 /* dec.c */; };
+		WEBB00000000000000002900 /* dec_clip_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000002900 /* dec_clip_tables.c */; };
+		WEBB00000000000000002A00 /* dec_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000002A00 /* dec_mips32.c */; };
+		WEBB00000000000000002B00 /* dec_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000002B00 /* dec_mips_dsp_r2.c */; };
+		WEBB00000000000000002C00 /* dec_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000002C00 /* dec_msa.c */; };
+		WEBB00000000000000002D00 /* dec_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000002D00 /* dec_neon.c */; };
+		WEBB00000000000000002E00 /* dec_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000002E00 /* dec_sse2.c */; };
+		WEBB00000000000000002F00 /* dec_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000002F00 /* dec_sse41.c */; };
+		WEBB00000000000000003000 /* enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000003000 /* enc.c */; };
+		WEBB00000000000000003100 /* enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000003100 /* enc_mips32.c */; };
+		WEBB00000000000000003200 /* enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000003200 /* enc_mips_dsp_r2.c */; };
+		WEBB00000000000000003300 /* enc_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000003300 /* enc_msa.c */; };
+		WEBB00000000000000003400 /* enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000003400 /* enc_neon.c */; };
+		WEBB00000000000000003500 /* enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000003500 /* enc_sse2.c */; };
+		WEBB00000000000000003600 /* enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000003600 /* enc_sse41.c */; };
+		WEBB00000000000000003700 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000003700 /* filters.c */; };
+		WEBB00000000000000003800 /* filters_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000003800 /* filters_mips_dsp_r2.c */; };
+		WEBB00000000000000003900 /* filters_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000003900 /* filters_msa.c */; };
+		WEBB00000000000000003A00 /* filters_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000003A00 /* filters_neon.c */; };
+		WEBB00000000000000003B00 /* filters_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000003B00 /* filters_sse2.c */; };
+		WEBB00000000000000003C00 /* lossless.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000003C00 /* lossless.c */; };
+		WEBB00000000000000003D00 /* lossless_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000003D00 /* lossless_enc.c */; };
+		WEBB00000000000000003E00 /* lossless_enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000003E00 /* lossless_enc_mips32.c */; };
+		WEBB00000000000000003F00 /* lossless_enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000003F00 /* lossless_enc_mips_dsp_r2.c */; };
+		WEBB00000000000000004000 /* lossless_enc_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000004000 /* lossless_enc_msa.c */; };
+		WEBB00000000000000004100 /* lossless_enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000004100 /* lossless_enc_neon.c */; };
+		WEBB00000000000000004200 /* lossless_enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000004200 /* lossless_enc_sse2.c */; };
+		WEBB00000000000000004300 /* lossless_enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000004300 /* lossless_enc_sse41.c */; };
+		WEBB00000000000000004400 /* lossless_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000004400 /* lossless_mips_dsp_r2.c */; };
+		WEBB00000000000000004500 /* lossless_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000004500 /* lossless_msa.c */; };
+		WEBB00000000000000004600 /* lossless_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000004600 /* lossless_neon.c */; };
+		WEBB00000000000000004700 /* lossless_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000004700 /* lossless_sse2.c */; };
+		WEBB00000000000000004800 /* lossless_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000004800 /* lossless_sse41.c */; };
+		WEBB00000000000000004900 /* rescaler.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000004900 /* rescaler.c */; };
+		WEBB00000000000000004A00 /* rescaler_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000004A00 /* rescaler_mips32.c */; };
+		WEBB00000000000000004B00 /* rescaler_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000004B00 /* rescaler_mips_dsp_r2.c */; };
+		WEBB00000000000000004C00 /* rescaler_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000004C00 /* rescaler_msa.c */; };
+		WEBB00000000000000004D00 /* rescaler_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000004D00 /* rescaler_neon.c */; };
+		WEBB00000000000000004E00 /* rescaler_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000004E00 /* rescaler_sse2.c */; };
+		WEBB00000000000000004F00 /* ssim.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000004F00 /* ssim.c */; };
+		WEBB00000000000000005000 /* ssim_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000005000 /* ssim_sse2.c */; };
+		WEBB00000000000000005100 /* upsampling.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000005100 /* upsampling.c */; };
+		WEBB00000000000000005200 /* upsampling_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000005200 /* upsampling_mips_dsp_r2.c */; };
+		WEBB00000000000000005300 /* upsampling_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000005300 /* upsampling_msa.c */; };
+		WEBB00000000000000005400 /* upsampling_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000005400 /* upsampling_neon.c */; };
+		WEBB00000000000000005500 /* upsampling_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000005500 /* upsampling_sse2.c */; };
+		WEBB00000000000000005600 /* upsampling_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000005600 /* upsampling_sse41.c */; };
+		WEBB00000000000000005700 /* yuv.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000005700 /* yuv.c */; };
+		WEBB00000000000000005800 /* yuv_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000005800 /* yuv_mips32.c */; };
+		WEBB00000000000000005900 /* yuv_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000005900 /* yuv_mips_dsp_r2.c */; };
+		WEBB00000000000000005A00 /* yuv_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000005A00 /* yuv_neon.c */; };
+		WEBB00000000000000005B00 /* yuv_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000005B00 /* yuv_sse2.c */; };
+		WEBB00000000000000005C00 /* yuv_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000005C00 /* yuv_sse41.c */; };
+		WEBB00000000000000005D00 /* alpha_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000005D00 /* alpha_enc.c */; };
+		WEBB00000000000000005E00 /* analysis_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000005E00 /* analysis_enc.c */; };
+		WEBB00000000000000005F00 /* backward_references_cost_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000005F00 /* backward_references_cost_enc.c */; };
+		WEBB00000000000000006000 /* backward_references_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000006000 /* backward_references_enc.c */; };
+		WEBB00000000000000006100 /* config_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000006100 /* config_enc.c */; };
+		WEBB00000000000000006200 /* cost_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000006200 /* cost_enc.c */; };
+		WEBB00000000000000006300 /* filter_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000006300 /* filter_enc.c */; };
+		WEBB00000000000000006400 /* frame_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000006400 /* frame_enc.c */; };
+		WEBB00000000000000006500 /* histogram_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000006500 /* histogram_enc.c */; };
+		WEBB00000000000000006600 /* iterator_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000006600 /* iterator_enc.c */; };
+		WEBB00000000000000006700 /* near_lossless_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000006700 /* near_lossless_enc.c */; };
+		WEBB00000000000000006800 /* picture_csp_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000006800 /* picture_csp_enc.c */; };
+		WEBB00000000000000006900 /* picture_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000006900 /* picture_enc.c */; };
+		WEBB00000000000000006A00 /* picture_psnr_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000006A00 /* picture_psnr_enc.c */; };
+		WEBB00000000000000006B00 /* picture_rescale_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000006B00 /* picture_rescale_enc.c */; };
+		WEBB00000000000000006C00 /* picture_tools_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000006C00 /* picture_tools_enc.c */; };
+		WEBB00000000000000006D00 /* predictor_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000006D00 /* predictor_enc.c */; };
+		WEBB00000000000000006E00 /* quant_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000006E00 /* quant_enc.c */; };
+		WEBB00000000000000006F00 /* syntax_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000006F00 /* syntax_enc.c */; };
+		WEBB00000000000000007000 /* token_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000007000 /* token_enc.c */; };
+		WEBB00000000000000007100 /* tree_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000007100 /* tree_enc.c */; };
+		WEBB00000000000000007200 /* vp8l_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000007200 /* vp8l_enc.c */; };
+		WEBB00000000000000007300 /* webp_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000007300 /* webp_enc.c */; };
+		WEBB00000000000000007400 /* bit_reader_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000007400 /* bit_reader_utils.c */; };
+		WEBB00000000000000007500 /* bit_writer_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000007500 /* bit_writer_utils.c */; };
+		WEBB00000000000000007600 /* color_cache_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000007600 /* color_cache_utils.c */; };
+		WEBB00000000000000007700 /* filters_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000007700 /* filters_utils.c */; };
+		WEBB00000000000000007800 /* huffman_encode_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000007800 /* huffman_encode_utils.c */; };
+		WEBB00000000000000007900 /* huffman_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000007900 /* huffman_utils.c */; };
+		WEBB00000000000000007A00 /* palette.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000007A00 /* palette.c */; };
+		WEBB00000000000000007B00 /* quant_levels_dec_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000007B00 /* quant_levels_dec_utils.c */; };
+		WEBB00000000000000007C00 /* quant_levels_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000007C00 /* quant_levels_utils.c */; };
+		WEBB00000000000000007D00 /* random_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000007D00 /* random_utils.c */; };
+		WEBB00000000000000007E00 /* rescaler_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000007E00 /* rescaler_utils.c */; };
+		WEBB00000000000000007F00 /* thread_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000007F00 /* thread_utils.c */; };
+		WEBB00000000000000008000 /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = WEBF00000000000000008000 /* utils.c */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		WEBP0000000000000000PRXY /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = WEBP0000000000000000PROJ /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = WEBP0000000000000000DOWN;
+			remoteInfo = download;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		WEBP0000000000000000PREF /* cwebp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = cwebp; sourceTree = BUILT_PRODUCTS_DIR; };
+		WEBP0000000000000000RELX /* release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = release.xcconfig; path = ../imageoptim/release.xcconfig; sourceTree = "<group>"; };
+		WEBP0000000000000000DBGX /* debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = debug.xcconfig; path = ../imageoptim/debug.xcconfig; sourceTree = "<group>"; };
+		WEBF00000000000000000000 /* cwebp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cwebp.c; path = examples/cwebp.c; sourceTree = "<group>"; };
+		WEBF00000000000000000100 /* example_util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = example_util.c; path = examples/example_util.c; sourceTree = "<group>"; };
+		WEBF00000000000000000200 /* image_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = image_dec.c; path = imageio/image_dec.c; sourceTree = "<group>"; };
+		WEBF00000000000000000300 /* imageio_util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = imageio_util.c; path = imageio/imageio_util.c; sourceTree = "<group>"; };
+		WEBF00000000000000000400 /* jpegdec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = jpegdec.c; path = imageio/jpegdec.c; sourceTree = "<group>"; };
+		WEBF00000000000000000500 /* metadata.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = metadata.c; path = imageio/metadata.c; sourceTree = "<group>"; };
+		WEBF00000000000000000600 /* pngdec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pngdec.c; path = imageio/pngdec.c; sourceTree = "<group>"; };
+		WEBF00000000000000000700 /* pnmdec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pnmdec.c; path = imageio/pnmdec.c; sourceTree = "<group>"; };
+		WEBF00000000000000000800 /* tiffdec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = tiffdec.c; path = imageio/tiffdec.c; sourceTree = "<group>"; };
+		WEBF00000000000000000900 /* webpdec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = webpdec.c; path = imageio/webpdec.c; sourceTree = "<group>"; };
+		WEBF00000000000000000A00 /* sharpyuv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sharpyuv.c; path = sharpyuv/sharpyuv.c; sourceTree = "<group>"; };
+		WEBF00000000000000000B00 /* sharpyuv_cpu.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sharpyuv_cpu.c; path = sharpyuv/sharpyuv_cpu.c; sourceTree = "<group>"; };
+		WEBF00000000000000000C00 /* sharpyuv_csp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sharpyuv_csp.c; path = sharpyuv/sharpyuv_csp.c; sourceTree = "<group>"; };
+		WEBF00000000000000000D00 /* sharpyuv_dsp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sharpyuv_dsp.c; path = sharpyuv/sharpyuv_dsp.c; sourceTree = "<group>"; };
+		WEBF00000000000000000E00 /* sharpyuv_gamma.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sharpyuv_gamma.c; path = sharpyuv/sharpyuv_gamma.c; sourceTree = "<group>"; };
+		WEBF00000000000000000F00 /* sharpyuv_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sharpyuv_neon.c; path = sharpyuv/sharpyuv_neon.c; sourceTree = "<group>"; };
+		WEBF00000000000000001000 /* sharpyuv_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sharpyuv_sse2.c; path = sharpyuv/sharpyuv_sse2.c; sourceTree = "<group>"; };
+		WEBF00000000000000001100 /* alpha_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = alpha_dec.c; path = src/dec/alpha_dec.c; sourceTree = "<group>"; };
+		WEBF00000000000000001200 /* buffer_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = buffer_dec.c; path = src/dec/buffer_dec.c; sourceTree = "<group>"; };
+		WEBF00000000000000001300 /* frame_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = frame_dec.c; path = src/dec/frame_dec.c; sourceTree = "<group>"; };
+		WEBF00000000000000001400 /* idec_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = idec_dec.c; path = src/dec/idec_dec.c; sourceTree = "<group>"; };
+		WEBF00000000000000001500 /* io_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = io_dec.c; path = src/dec/io_dec.c; sourceTree = "<group>"; };
+		WEBF00000000000000001600 /* quant_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = quant_dec.c; path = src/dec/quant_dec.c; sourceTree = "<group>"; };
+		WEBF00000000000000001700 /* tree_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = tree_dec.c; path = src/dec/tree_dec.c; sourceTree = "<group>"; };
+		WEBF00000000000000001800 /* vp8_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = vp8_dec.c; path = src/dec/vp8_dec.c; sourceTree = "<group>"; };
+		WEBF00000000000000001900 /* vp8l_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = vp8l_dec.c; path = src/dec/vp8l_dec.c; sourceTree = "<group>"; };
+		WEBF00000000000000001A00 /* webp_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = webp_dec.c; path = src/dec/webp_dec.c; sourceTree = "<group>"; };
+		WEBF00000000000000001B00 /* anim_decode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = anim_decode.c; path = src/demux/anim_decode.c; sourceTree = "<group>"; };
+		WEBF00000000000000001C00 /* demux.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = demux.c; path = src/demux/demux.c; sourceTree = "<group>"; };
+		WEBF00000000000000001D00 /* alpha_processing.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = alpha_processing.c; path = src/dsp/alpha_processing.c; sourceTree = "<group>"; };
+		WEBF00000000000000001E00 /* alpha_processing_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = alpha_processing_mips_dsp_r2.c; path = src/dsp/alpha_processing_mips_dsp_r2.c; sourceTree = "<group>"; };
+		WEBF00000000000000001F00 /* alpha_processing_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = alpha_processing_neon.c; path = src/dsp/alpha_processing_neon.c; sourceTree = "<group>"; };
+		WEBF00000000000000002000 /* alpha_processing_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = alpha_processing_sse2.c; path = src/dsp/alpha_processing_sse2.c; sourceTree = "<group>"; };
+		WEBF00000000000000002100 /* alpha_processing_sse41.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = alpha_processing_sse41.c; path = src/dsp/alpha_processing_sse41.c; sourceTree = "<group>"; };
+		WEBF00000000000000002200 /* cost.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cost.c; path = src/dsp/cost.c; sourceTree = "<group>"; };
+		WEBF00000000000000002300 /* cost_mips32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cost_mips32.c; path = src/dsp/cost_mips32.c; sourceTree = "<group>"; };
+		WEBF00000000000000002400 /* cost_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cost_mips_dsp_r2.c; path = src/dsp/cost_mips_dsp_r2.c; sourceTree = "<group>"; };
+		WEBF00000000000000002500 /* cost_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cost_neon.c; path = src/dsp/cost_neon.c; sourceTree = "<group>"; };
+		WEBF00000000000000002600 /* cost_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cost_sse2.c; path = src/dsp/cost_sse2.c; sourceTree = "<group>"; };
+		WEBF00000000000000002700 /* cpu.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cpu.c; path = src/dsp/cpu.c; sourceTree = "<group>"; };
+		WEBF00000000000000002800 /* dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = dec.c; path = src/dsp/dec.c; sourceTree = "<group>"; };
+		WEBF00000000000000002900 /* dec_clip_tables.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = dec_clip_tables.c; path = src/dsp/dec_clip_tables.c; sourceTree = "<group>"; };
+		WEBF00000000000000002A00 /* dec_mips32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = dec_mips32.c; path = src/dsp/dec_mips32.c; sourceTree = "<group>"; };
+		WEBF00000000000000002B00 /* dec_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = dec_mips_dsp_r2.c; path = src/dsp/dec_mips_dsp_r2.c; sourceTree = "<group>"; };
+		WEBF00000000000000002C00 /* dec_msa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = dec_msa.c; path = src/dsp/dec_msa.c; sourceTree = "<group>"; };
+		WEBF00000000000000002D00 /* dec_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = dec_neon.c; path = src/dsp/dec_neon.c; sourceTree = "<group>"; };
+		WEBF00000000000000002E00 /* dec_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = dec_sse2.c; path = src/dsp/dec_sse2.c; sourceTree = "<group>"; };
+		WEBF00000000000000002F00 /* dec_sse41.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = dec_sse41.c; path = src/dsp/dec_sse41.c; sourceTree = "<group>"; };
+		WEBF00000000000000003000 /* enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = enc.c; path = src/dsp/enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000003100 /* enc_mips32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = enc_mips32.c; path = src/dsp/enc_mips32.c; sourceTree = "<group>"; };
+		WEBF00000000000000003200 /* enc_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = enc_mips_dsp_r2.c; path = src/dsp/enc_mips_dsp_r2.c; sourceTree = "<group>"; };
+		WEBF00000000000000003300 /* enc_msa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = enc_msa.c; path = src/dsp/enc_msa.c; sourceTree = "<group>"; };
+		WEBF00000000000000003400 /* enc_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = enc_neon.c; path = src/dsp/enc_neon.c; sourceTree = "<group>"; };
+		WEBF00000000000000003500 /* enc_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = enc_sse2.c; path = src/dsp/enc_sse2.c; sourceTree = "<group>"; };
+		WEBF00000000000000003600 /* enc_sse41.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = enc_sse41.c; path = src/dsp/enc_sse41.c; sourceTree = "<group>"; };
+		WEBF00000000000000003700 /* filters.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = filters.c; path = src/dsp/filters.c; sourceTree = "<group>"; };
+		WEBF00000000000000003800 /* filters_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = filters_mips_dsp_r2.c; path = src/dsp/filters_mips_dsp_r2.c; sourceTree = "<group>"; };
+		WEBF00000000000000003900 /* filters_msa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = filters_msa.c; path = src/dsp/filters_msa.c; sourceTree = "<group>"; };
+		WEBF00000000000000003A00 /* filters_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = filters_neon.c; path = src/dsp/filters_neon.c; sourceTree = "<group>"; };
+		WEBF00000000000000003B00 /* filters_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = filters_sse2.c; path = src/dsp/filters_sse2.c; sourceTree = "<group>"; };
+		WEBF00000000000000003C00 /* lossless.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lossless.c; path = src/dsp/lossless.c; sourceTree = "<group>"; };
+		WEBF00000000000000003D00 /* lossless_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lossless_enc.c; path = src/dsp/lossless_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000003E00 /* lossless_enc_mips32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lossless_enc_mips32.c; path = src/dsp/lossless_enc_mips32.c; sourceTree = "<group>"; };
+		WEBF00000000000000003F00 /* lossless_enc_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lossless_enc_mips_dsp_r2.c; path = src/dsp/lossless_enc_mips_dsp_r2.c; sourceTree = "<group>"; };
+		WEBF00000000000000004000 /* lossless_enc_msa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lossless_enc_msa.c; path = src/dsp/lossless_enc_msa.c; sourceTree = "<group>"; };
+		WEBF00000000000000004100 /* lossless_enc_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lossless_enc_neon.c; path = src/dsp/lossless_enc_neon.c; sourceTree = "<group>"; };
+		WEBF00000000000000004200 /* lossless_enc_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lossless_enc_sse2.c; path = src/dsp/lossless_enc_sse2.c; sourceTree = "<group>"; };
+		WEBF00000000000000004300 /* lossless_enc_sse41.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lossless_enc_sse41.c; path = src/dsp/lossless_enc_sse41.c; sourceTree = "<group>"; };
+		WEBF00000000000000004400 /* lossless_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lossless_mips_dsp_r2.c; path = src/dsp/lossless_mips_dsp_r2.c; sourceTree = "<group>"; };
+		WEBF00000000000000004500 /* lossless_msa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lossless_msa.c; path = src/dsp/lossless_msa.c; sourceTree = "<group>"; };
+		WEBF00000000000000004600 /* lossless_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lossless_neon.c; path = src/dsp/lossless_neon.c; sourceTree = "<group>"; };
+		WEBF00000000000000004700 /* lossless_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lossless_sse2.c; path = src/dsp/lossless_sse2.c; sourceTree = "<group>"; };
+		WEBF00000000000000004800 /* lossless_sse41.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lossless_sse41.c; path = src/dsp/lossless_sse41.c; sourceTree = "<group>"; };
+		WEBF00000000000000004900 /* rescaler.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = rescaler.c; path = src/dsp/rescaler.c; sourceTree = "<group>"; };
+		WEBF00000000000000004A00 /* rescaler_mips32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = rescaler_mips32.c; path = src/dsp/rescaler_mips32.c; sourceTree = "<group>"; };
+		WEBF00000000000000004B00 /* rescaler_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = rescaler_mips_dsp_r2.c; path = src/dsp/rescaler_mips_dsp_r2.c; sourceTree = "<group>"; };
+		WEBF00000000000000004C00 /* rescaler_msa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = rescaler_msa.c; path = src/dsp/rescaler_msa.c; sourceTree = "<group>"; };
+		WEBF00000000000000004D00 /* rescaler_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = rescaler_neon.c; path = src/dsp/rescaler_neon.c; sourceTree = "<group>"; };
+		WEBF00000000000000004E00 /* rescaler_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = rescaler_sse2.c; path = src/dsp/rescaler_sse2.c; sourceTree = "<group>"; };
+		WEBF00000000000000004F00 /* ssim.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ssim.c; path = src/dsp/ssim.c; sourceTree = "<group>"; };
+		WEBF00000000000000005000 /* ssim_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ssim_sse2.c; path = src/dsp/ssim_sse2.c; sourceTree = "<group>"; };
+		WEBF00000000000000005100 /* upsampling.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = upsampling.c; path = src/dsp/upsampling.c; sourceTree = "<group>"; };
+		WEBF00000000000000005200 /* upsampling_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = upsampling_mips_dsp_r2.c; path = src/dsp/upsampling_mips_dsp_r2.c; sourceTree = "<group>"; };
+		WEBF00000000000000005300 /* upsampling_msa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = upsampling_msa.c; path = src/dsp/upsampling_msa.c; sourceTree = "<group>"; };
+		WEBF00000000000000005400 /* upsampling_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = upsampling_neon.c; path = src/dsp/upsampling_neon.c; sourceTree = "<group>"; };
+		WEBF00000000000000005500 /* upsampling_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = upsampling_sse2.c; path = src/dsp/upsampling_sse2.c; sourceTree = "<group>"; };
+		WEBF00000000000000005600 /* upsampling_sse41.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = upsampling_sse41.c; path = src/dsp/upsampling_sse41.c; sourceTree = "<group>"; };
+		WEBF00000000000000005700 /* yuv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = yuv.c; path = src/dsp/yuv.c; sourceTree = "<group>"; };
+		WEBF00000000000000005800 /* yuv_mips32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = yuv_mips32.c; path = src/dsp/yuv_mips32.c; sourceTree = "<group>"; };
+		WEBF00000000000000005900 /* yuv_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = yuv_mips_dsp_r2.c; path = src/dsp/yuv_mips_dsp_r2.c; sourceTree = "<group>"; };
+		WEBF00000000000000005A00 /* yuv_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = yuv_neon.c; path = src/dsp/yuv_neon.c; sourceTree = "<group>"; };
+		WEBF00000000000000005B00 /* yuv_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = yuv_sse2.c; path = src/dsp/yuv_sse2.c; sourceTree = "<group>"; };
+		WEBF00000000000000005C00 /* yuv_sse41.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = yuv_sse41.c; path = src/dsp/yuv_sse41.c; sourceTree = "<group>"; };
+		WEBF00000000000000005D00 /* alpha_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = alpha_enc.c; path = src/enc/alpha_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000005E00 /* analysis_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = analysis_enc.c; path = src/enc/analysis_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000005F00 /* backward_references_cost_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = backward_references_cost_enc.c; path = src/enc/backward_references_cost_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000006000 /* backward_references_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = backward_references_enc.c; path = src/enc/backward_references_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000006100 /* config_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = config_enc.c; path = src/enc/config_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000006200 /* cost_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cost_enc.c; path = src/enc/cost_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000006300 /* filter_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = filter_enc.c; path = src/enc/filter_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000006400 /* frame_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = frame_enc.c; path = src/enc/frame_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000006500 /* histogram_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = histogram_enc.c; path = src/enc/histogram_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000006600 /* iterator_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = iterator_enc.c; path = src/enc/iterator_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000006700 /* near_lossless_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = near_lossless_enc.c; path = src/enc/near_lossless_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000006800 /* picture_csp_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = picture_csp_enc.c; path = src/enc/picture_csp_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000006900 /* picture_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = picture_enc.c; path = src/enc/picture_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000006A00 /* picture_psnr_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = picture_psnr_enc.c; path = src/enc/picture_psnr_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000006B00 /* picture_rescale_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = picture_rescale_enc.c; path = src/enc/picture_rescale_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000006C00 /* picture_tools_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = picture_tools_enc.c; path = src/enc/picture_tools_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000006D00 /* predictor_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = predictor_enc.c; path = src/enc/predictor_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000006E00 /* quant_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = quant_enc.c; path = src/enc/quant_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000006F00 /* syntax_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = syntax_enc.c; path = src/enc/syntax_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000007000 /* token_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = token_enc.c; path = src/enc/token_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000007100 /* tree_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = tree_enc.c; path = src/enc/tree_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000007200 /* vp8l_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = vp8l_enc.c; path = src/enc/vp8l_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000007300 /* webp_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = webp_enc.c; path = src/enc/webp_enc.c; sourceTree = "<group>"; };
+		WEBF00000000000000007400 /* bit_reader_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = bit_reader_utils.c; path = src/utils/bit_reader_utils.c; sourceTree = "<group>"; };
+		WEBF00000000000000007500 /* bit_writer_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = bit_writer_utils.c; path = src/utils/bit_writer_utils.c; sourceTree = "<group>"; };
+		WEBF00000000000000007600 /* color_cache_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = color_cache_utils.c; path = src/utils/color_cache_utils.c; sourceTree = "<group>"; };
+		WEBF00000000000000007700 /* filters_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = filters_utils.c; path = src/utils/filters_utils.c; sourceTree = "<group>"; };
+		WEBF00000000000000007800 /* huffman_encode_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = huffman_encode_utils.c; path = src/utils/huffman_encode_utils.c; sourceTree = "<group>"; };
+		WEBF00000000000000007900 /* huffman_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = huffman_utils.c; path = src/utils/huffman_utils.c; sourceTree = "<group>"; };
+		WEBF00000000000000007A00 /* palette.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = palette.c; path = src/utils/palette.c; sourceTree = "<group>"; };
+		WEBF00000000000000007B00 /* quant_levels_dec_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = quant_levels_dec_utils.c; path = src/utils/quant_levels_dec_utils.c; sourceTree = "<group>"; };
+		WEBF00000000000000007C00 /* quant_levels_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = quant_levels_utils.c; path = src/utils/quant_levels_utils.c; sourceTree = "<group>"; };
+		WEBF00000000000000007D00 /* random_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = random_utils.c; path = src/utils/random_utils.c; sourceTree = "<group>"; };
+		WEBF00000000000000007E00 /* rescaler_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = rescaler_utils.c; path = src/utils/rescaler_utils.c; sourceTree = "<group>"; };
+		WEBF00000000000000007F00 /* thread_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = thread_utils.c; path = src/utils/thread_utils.c; sourceTree = "<group>"; };
+		WEBF00000000000000008000 /* utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = utils.c; path = src/utils/utils.c; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		WEBP0000000000000000FRMW /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		WEBP0000000000000000MAIN = {
+			isa = PBXGroup;
+			children = (
+				WEBP0000000000000000PROD /* Products */,
+				WEBP0000000000000000SRCG /* Source */,
+				WEBP0000000000000000DBGX /* debug.xcconfig */,
+				WEBP0000000000000000RELX /* release.xcconfig */,
+			);
+			sourceTree = "<group>";
+		};
+		WEBP0000000000000000PROD /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				WEBP0000000000000000PREF /* cwebp */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		WEBP0000000000000000SRCG /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				WEBF00000000000000000000 /* cwebp.c */,
+				WEBF00000000000000000100 /* example_util.c */,
+				WEBF00000000000000000200 /* image_dec.c */,
+				WEBF00000000000000000300 /* imageio_util.c */,
+				WEBF00000000000000000400 /* jpegdec.c */,
+				WEBF00000000000000000500 /* metadata.c */,
+				WEBF00000000000000000600 /* pngdec.c */,
+				WEBF00000000000000000700 /* pnmdec.c */,
+				WEBF00000000000000000800 /* tiffdec.c */,
+				WEBF00000000000000000900 /* webpdec.c */,
+				WEBF00000000000000000A00 /* sharpyuv.c */,
+				WEBF00000000000000000B00 /* sharpyuv_cpu.c */,
+				WEBF00000000000000000C00 /* sharpyuv_csp.c */,
+				WEBF00000000000000000D00 /* sharpyuv_dsp.c */,
+				WEBF00000000000000000E00 /* sharpyuv_gamma.c */,
+				WEBF00000000000000000F00 /* sharpyuv_neon.c */,
+				WEBF00000000000000001000 /* sharpyuv_sse2.c */,
+				WEBF00000000000000001100 /* alpha_dec.c */,
+				WEBF00000000000000001200 /* buffer_dec.c */,
+				WEBF00000000000000001300 /* frame_dec.c */,
+				WEBF00000000000000001400 /* idec_dec.c */,
+				WEBF00000000000000001500 /* io_dec.c */,
+				WEBF00000000000000001600 /* quant_dec.c */,
+				WEBF00000000000000001700 /* tree_dec.c */,
+				WEBF00000000000000001800 /* vp8_dec.c */,
+				WEBF00000000000000001900 /* vp8l_dec.c */,
+				WEBF00000000000000001A00 /* webp_dec.c */,
+				WEBF00000000000000001B00 /* anim_decode.c */,
+				WEBF00000000000000001C00 /* demux.c */,
+				WEBF00000000000000001D00 /* alpha_processing.c */,
+				WEBF00000000000000001E00 /* alpha_processing_mips_dsp_r2.c */,
+				WEBF00000000000000001F00 /* alpha_processing_neon.c */,
+				WEBF00000000000000002000 /* alpha_processing_sse2.c */,
+				WEBF00000000000000002100 /* alpha_processing_sse41.c */,
+				WEBF00000000000000002200 /* cost.c */,
+				WEBF00000000000000002300 /* cost_mips32.c */,
+				WEBF00000000000000002400 /* cost_mips_dsp_r2.c */,
+				WEBF00000000000000002500 /* cost_neon.c */,
+				WEBF00000000000000002600 /* cost_sse2.c */,
+				WEBF00000000000000002700 /* cpu.c */,
+				WEBF00000000000000002800 /* dec.c */,
+				WEBF00000000000000002900 /* dec_clip_tables.c */,
+				WEBF00000000000000002A00 /* dec_mips32.c */,
+				WEBF00000000000000002B00 /* dec_mips_dsp_r2.c */,
+				WEBF00000000000000002C00 /* dec_msa.c */,
+				WEBF00000000000000002D00 /* dec_neon.c */,
+				WEBF00000000000000002E00 /* dec_sse2.c */,
+				WEBF00000000000000002F00 /* dec_sse41.c */,
+				WEBF00000000000000003000 /* enc.c */,
+				WEBF00000000000000003100 /* enc_mips32.c */,
+				WEBF00000000000000003200 /* enc_mips_dsp_r2.c */,
+				WEBF00000000000000003300 /* enc_msa.c */,
+				WEBF00000000000000003400 /* enc_neon.c */,
+				WEBF00000000000000003500 /* enc_sse2.c */,
+				WEBF00000000000000003600 /* enc_sse41.c */,
+				WEBF00000000000000003700 /* filters.c */,
+				WEBF00000000000000003800 /* filters_mips_dsp_r2.c */,
+				WEBF00000000000000003900 /* filters_msa.c */,
+				WEBF00000000000000003A00 /* filters_neon.c */,
+				WEBF00000000000000003B00 /* filters_sse2.c */,
+				WEBF00000000000000003C00 /* lossless.c */,
+				WEBF00000000000000003D00 /* lossless_enc.c */,
+				WEBF00000000000000003E00 /* lossless_enc_mips32.c */,
+				WEBF00000000000000003F00 /* lossless_enc_mips_dsp_r2.c */,
+				WEBF00000000000000004000 /* lossless_enc_msa.c */,
+				WEBF00000000000000004100 /* lossless_enc_neon.c */,
+				WEBF00000000000000004200 /* lossless_enc_sse2.c */,
+				WEBF00000000000000004300 /* lossless_enc_sse41.c */,
+				WEBF00000000000000004400 /* lossless_mips_dsp_r2.c */,
+				WEBF00000000000000004500 /* lossless_msa.c */,
+				WEBF00000000000000004600 /* lossless_neon.c */,
+				WEBF00000000000000004700 /* lossless_sse2.c */,
+				WEBF00000000000000004800 /* lossless_sse41.c */,
+				WEBF00000000000000004900 /* rescaler.c */,
+				WEBF00000000000000004A00 /* rescaler_mips32.c */,
+				WEBF00000000000000004B00 /* rescaler_mips_dsp_r2.c */,
+				WEBF00000000000000004C00 /* rescaler_msa.c */,
+				WEBF00000000000000004D00 /* rescaler_neon.c */,
+				WEBF00000000000000004E00 /* rescaler_sse2.c */,
+				WEBF00000000000000004F00 /* ssim.c */,
+				WEBF00000000000000005000 /* ssim_sse2.c */,
+				WEBF00000000000000005100 /* upsampling.c */,
+				WEBF00000000000000005200 /* upsampling_mips_dsp_r2.c */,
+				WEBF00000000000000005300 /* upsampling_msa.c */,
+				WEBF00000000000000005400 /* upsampling_neon.c */,
+				WEBF00000000000000005500 /* upsampling_sse2.c */,
+				WEBF00000000000000005600 /* upsampling_sse41.c */,
+				WEBF00000000000000005700 /* yuv.c */,
+				WEBF00000000000000005800 /* yuv_mips32.c */,
+				WEBF00000000000000005900 /* yuv_mips_dsp_r2.c */,
+				WEBF00000000000000005A00 /* yuv_neon.c */,
+				WEBF00000000000000005B00 /* yuv_sse2.c */,
+				WEBF00000000000000005C00 /* yuv_sse41.c */,
+				WEBF00000000000000005D00 /* alpha_enc.c */,
+				WEBF00000000000000005E00 /* analysis_enc.c */,
+				WEBF00000000000000005F00 /* backward_references_cost_enc.c */,
+				WEBF00000000000000006000 /* backward_references_enc.c */,
+				WEBF00000000000000006100 /* config_enc.c */,
+				WEBF00000000000000006200 /* cost_enc.c */,
+				WEBF00000000000000006300 /* filter_enc.c */,
+				WEBF00000000000000006400 /* frame_enc.c */,
+				WEBF00000000000000006500 /* histogram_enc.c */,
+				WEBF00000000000000006600 /* iterator_enc.c */,
+				WEBF00000000000000006700 /* near_lossless_enc.c */,
+				WEBF00000000000000006800 /* picture_csp_enc.c */,
+				WEBF00000000000000006900 /* picture_enc.c */,
+				WEBF00000000000000006A00 /* picture_psnr_enc.c */,
+				WEBF00000000000000006B00 /* picture_rescale_enc.c */,
+				WEBF00000000000000006C00 /* picture_tools_enc.c */,
+				WEBF00000000000000006D00 /* predictor_enc.c */,
+				WEBF00000000000000006E00 /* quant_enc.c */,
+				WEBF00000000000000006F00 /* syntax_enc.c */,
+				WEBF00000000000000007000 /* token_enc.c */,
+				WEBF00000000000000007100 /* tree_enc.c */,
+				WEBF00000000000000007200 /* vp8l_enc.c */,
+				WEBF00000000000000007300 /* webp_enc.c */,
+				WEBF00000000000000007400 /* bit_reader_utils.c */,
+				WEBF00000000000000007500 /* bit_writer_utils.c */,
+				WEBF00000000000000007600 /* color_cache_utils.c */,
+				WEBF00000000000000007700 /* filters_utils.c */,
+				WEBF00000000000000007800 /* huffman_encode_utils.c */,
+				WEBF00000000000000007900 /* huffman_utils.c */,
+				WEBF00000000000000007A00 /* palette.c */,
+				WEBF00000000000000007B00 /* quant_levels_dec_utils.c */,
+				WEBF00000000000000007C00 /* quant_levels_utils.c */,
+				WEBF00000000000000007D00 /* random_utils.c */,
+				WEBF00000000000000007E00 /* rescaler_utils.c */,
+				WEBF00000000000000007F00 /* thread_utils.c */,
+				WEBF00000000000000008000 /* utils.c */,
+			);
+			name = Source;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXLegacyTarget section */
+		WEBP0000000000000000DOWN /* download */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "$(ACTION)";
+			buildConfigurationList = WEBP0000000000000000DLST /* Build configuration list for PBXLegacyTarget "download" */;
+			buildPhases = (
+			);
+			buildToolPath = /usr/bin/make;
+			buildWorkingDirectory = "";
+			dependencies = (
+			);
+			name = download;
+			passBuildSettingsInEnvironment = 1;
+			productName = download;
+		};
+/* End PBXLegacyTarget section */
+
+/* Begin PBXNativeTarget section */
+		WEBP0000000000000000TOOL /* cwebp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = WEBP0000000000000000TLST /* Build configuration list for PBXNativeTarget "cwebp" */;
+			buildPhases = (
+				WEBP0000000000000000SRCP /* Sources */,
+				WEBP0000000000000000FRMW /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				WEBP0000000000000000TDEP /* PBXTargetDependency */,
+			);
+			name = cwebp;
+			productName = cwebp;
+			productReference = WEBP0000000000000000PREF /* cwebp */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		WEBP0000000000000000PROJ /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1500;
+			};
+			buildConfigurationList = WEBP0000000000000000PLST /* Build configuration list for PBXProject "libwebp" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				English,
+				en,
+			);
+			mainGroup = WEBP0000000000000000MAIN;
+			productRefGroup = WEBP0000000000000000PROD /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				WEBP0000000000000000TOOL /* cwebp */,
+				WEBP0000000000000000DOWN /* download */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		WEBP0000000000000000SRCP /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				WEBB00000000000000000000 /* cwebp.c in Sources */,
+				WEBB00000000000000000100 /* example_util.c in Sources */,
+				WEBB00000000000000000200 /* image_dec.c in Sources */,
+				WEBB00000000000000000300 /* imageio_util.c in Sources */,
+				WEBB00000000000000000400 /* jpegdec.c in Sources */,
+				WEBB00000000000000000500 /* metadata.c in Sources */,
+				WEBB00000000000000000600 /* pngdec.c in Sources */,
+				WEBB00000000000000000700 /* pnmdec.c in Sources */,
+				WEBB00000000000000000800 /* tiffdec.c in Sources */,
+				WEBB00000000000000000900 /* webpdec.c in Sources */,
+				WEBB00000000000000000A00 /* sharpyuv.c in Sources */,
+				WEBB00000000000000000B00 /* sharpyuv_cpu.c in Sources */,
+				WEBB00000000000000000C00 /* sharpyuv_csp.c in Sources */,
+				WEBB00000000000000000D00 /* sharpyuv_dsp.c in Sources */,
+				WEBB00000000000000000E00 /* sharpyuv_gamma.c in Sources */,
+				WEBB00000000000000000F00 /* sharpyuv_neon.c in Sources */,
+				WEBB00000000000000001000 /* sharpyuv_sse2.c in Sources */,
+				WEBB00000000000000001100 /* alpha_dec.c in Sources */,
+				WEBB00000000000000001200 /* buffer_dec.c in Sources */,
+				WEBB00000000000000001300 /* frame_dec.c in Sources */,
+				WEBB00000000000000001400 /* idec_dec.c in Sources */,
+				WEBB00000000000000001500 /* io_dec.c in Sources */,
+				WEBB00000000000000001600 /* quant_dec.c in Sources */,
+				WEBB00000000000000001700 /* tree_dec.c in Sources */,
+				WEBB00000000000000001800 /* vp8_dec.c in Sources */,
+				WEBB00000000000000001900 /* vp8l_dec.c in Sources */,
+				WEBB00000000000000001A00 /* webp_dec.c in Sources */,
+				WEBB00000000000000001B00 /* anim_decode.c in Sources */,
+				WEBB00000000000000001C00 /* demux.c in Sources */,
+				WEBB00000000000000001D00 /* alpha_processing.c in Sources */,
+				WEBB00000000000000001E00 /* alpha_processing_mips_dsp_r2.c in Sources */,
+				WEBB00000000000000001F00 /* alpha_processing_neon.c in Sources */,
+				WEBB00000000000000002000 /* alpha_processing_sse2.c in Sources */,
+				WEBB00000000000000002100 /* alpha_processing_sse41.c in Sources */,
+				WEBB00000000000000002200 /* cost.c in Sources */,
+				WEBB00000000000000002300 /* cost_mips32.c in Sources */,
+				WEBB00000000000000002400 /* cost_mips_dsp_r2.c in Sources */,
+				WEBB00000000000000002500 /* cost_neon.c in Sources */,
+				WEBB00000000000000002600 /* cost_sse2.c in Sources */,
+				WEBB00000000000000002700 /* cpu.c in Sources */,
+				WEBB00000000000000002800 /* dec.c in Sources */,
+				WEBB00000000000000002900 /* dec_clip_tables.c in Sources */,
+				WEBB00000000000000002A00 /* dec_mips32.c in Sources */,
+				WEBB00000000000000002B00 /* dec_mips_dsp_r2.c in Sources */,
+				WEBB00000000000000002C00 /* dec_msa.c in Sources */,
+				WEBB00000000000000002D00 /* dec_neon.c in Sources */,
+				WEBB00000000000000002E00 /* dec_sse2.c in Sources */,
+				WEBB00000000000000002F00 /* dec_sse41.c in Sources */,
+				WEBB00000000000000003000 /* enc.c in Sources */,
+				WEBB00000000000000003100 /* enc_mips32.c in Sources */,
+				WEBB00000000000000003200 /* enc_mips_dsp_r2.c in Sources */,
+				WEBB00000000000000003300 /* enc_msa.c in Sources */,
+				WEBB00000000000000003400 /* enc_neon.c in Sources */,
+				WEBB00000000000000003500 /* enc_sse2.c in Sources */,
+				WEBB00000000000000003600 /* enc_sse41.c in Sources */,
+				WEBB00000000000000003700 /* filters.c in Sources */,
+				WEBB00000000000000003800 /* filters_mips_dsp_r2.c in Sources */,
+				WEBB00000000000000003900 /* filters_msa.c in Sources */,
+				WEBB00000000000000003A00 /* filters_neon.c in Sources */,
+				WEBB00000000000000003B00 /* filters_sse2.c in Sources */,
+				WEBB00000000000000003C00 /* lossless.c in Sources */,
+				WEBB00000000000000003D00 /* lossless_enc.c in Sources */,
+				WEBB00000000000000003E00 /* lossless_enc_mips32.c in Sources */,
+				WEBB00000000000000003F00 /* lossless_enc_mips_dsp_r2.c in Sources */,
+				WEBB00000000000000004000 /* lossless_enc_msa.c in Sources */,
+				WEBB00000000000000004100 /* lossless_enc_neon.c in Sources */,
+				WEBB00000000000000004200 /* lossless_enc_sse2.c in Sources */,
+				WEBB00000000000000004300 /* lossless_enc_sse41.c in Sources */,
+				WEBB00000000000000004400 /* lossless_mips_dsp_r2.c in Sources */,
+				WEBB00000000000000004500 /* lossless_msa.c in Sources */,
+				WEBB00000000000000004600 /* lossless_neon.c in Sources */,
+				WEBB00000000000000004700 /* lossless_sse2.c in Sources */,
+				WEBB00000000000000004800 /* lossless_sse41.c in Sources */,
+				WEBB00000000000000004900 /* rescaler.c in Sources */,
+				WEBB00000000000000004A00 /* rescaler_mips32.c in Sources */,
+				WEBB00000000000000004B00 /* rescaler_mips_dsp_r2.c in Sources */,
+				WEBB00000000000000004C00 /* rescaler_msa.c in Sources */,
+				WEBB00000000000000004D00 /* rescaler_neon.c in Sources */,
+				WEBB00000000000000004E00 /* rescaler_sse2.c in Sources */,
+				WEBB00000000000000004F00 /* ssim.c in Sources */,
+				WEBB00000000000000005000 /* ssim_sse2.c in Sources */,
+				WEBB00000000000000005100 /* upsampling.c in Sources */,
+				WEBB00000000000000005200 /* upsampling_mips_dsp_r2.c in Sources */,
+				WEBB00000000000000005300 /* upsampling_msa.c in Sources */,
+				WEBB00000000000000005400 /* upsampling_neon.c in Sources */,
+				WEBB00000000000000005500 /* upsampling_sse2.c in Sources */,
+				WEBB00000000000000005600 /* upsampling_sse41.c in Sources */,
+				WEBB00000000000000005700 /* yuv.c in Sources */,
+				WEBB00000000000000005800 /* yuv_mips32.c in Sources */,
+				WEBB00000000000000005900 /* yuv_mips_dsp_r2.c in Sources */,
+				WEBB00000000000000005A00 /* yuv_neon.c in Sources */,
+				WEBB00000000000000005B00 /* yuv_sse2.c in Sources */,
+				WEBB00000000000000005C00 /* yuv_sse41.c in Sources */,
+				WEBB00000000000000005D00 /* alpha_enc.c in Sources */,
+				WEBB00000000000000005E00 /* analysis_enc.c in Sources */,
+				WEBB00000000000000005F00 /* backward_references_cost_enc.c in Sources */,
+				WEBB00000000000000006000 /* backward_references_enc.c in Sources */,
+				WEBB00000000000000006100 /* config_enc.c in Sources */,
+				WEBB00000000000000006200 /* cost_enc.c in Sources */,
+				WEBB00000000000000006300 /* filter_enc.c in Sources */,
+				WEBB00000000000000006400 /* frame_enc.c in Sources */,
+				WEBB00000000000000006500 /* histogram_enc.c in Sources */,
+				WEBB00000000000000006600 /* iterator_enc.c in Sources */,
+				WEBB00000000000000006700 /* near_lossless_enc.c in Sources */,
+				WEBB00000000000000006800 /* picture_csp_enc.c in Sources */,
+				WEBB00000000000000006900 /* picture_enc.c in Sources */,
+				WEBB00000000000000006A00 /* picture_psnr_enc.c in Sources */,
+				WEBB00000000000000006B00 /* picture_rescale_enc.c in Sources */,
+				WEBB00000000000000006C00 /* picture_tools_enc.c in Sources */,
+				WEBB00000000000000006D00 /* predictor_enc.c in Sources */,
+				WEBB00000000000000006E00 /* quant_enc.c in Sources */,
+				WEBB00000000000000006F00 /* syntax_enc.c in Sources */,
+				WEBB00000000000000007000 /* token_enc.c in Sources */,
+				WEBB00000000000000007100 /* tree_enc.c in Sources */,
+				WEBB00000000000000007200 /* vp8l_enc.c in Sources */,
+				WEBB00000000000000007300 /* webp_enc.c in Sources */,
+				WEBB00000000000000007400 /* bit_reader_utils.c in Sources */,
+				WEBB00000000000000007500 /* bit_writer_utils.c in Sources */,
+				WEBB00000000000000007600 /* color_cache_utils.c in Sources */,
+				WEBB00000000000000007700 /* filters_utils.c in Sources */,
+				WEBB00000000000000007800 /* huffman_encode_utils.c in Sources */,
+				WEBB00000000000000007900 /* huffman_utils.c in Sources */,
+				WEBB00000000000000007A00 /* palette.c in Sources */,
+				WEBB00000000000000007B00 /* quant_levels_dec_utils.c in Sources */,
+				WEBB00000000000000007C00 /* quant_levels_utils.c in Sources */,
+				WEBB00000000000000007D00 /* random_utils.c in Sources */,
+				WEBB00000000000000007E00 /* rescaler_utils.c in Sources */,
+				WEBB00000000000000007F00 /* thread_utils.c in Sources */,
+				WEBB00000000000000008000 /* utils.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		WEBP0000000000000000TDEP /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = WEBP0000000000000000DOWN /* download */;
+			targetProxy = WEBP0000000000000000PRXY /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		WEBP0000000000000000PCGD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = WEBP0000000000000000DBGX /* debug.xcconfig */;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					NDEBUG,
+					NS_BLOCK_ASSERTIONS,
+					WEBP_USE_THREAD,
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)",
+					"$(SRCROOT)/src",
+				);
+				ONLY_ACTIVE_ARCH = YES;
+			};
+			name = Debug;
+		};
+		WEBP0000000000000000PCGR /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = WEBP0000000000000000RELX /* release.xcconfig */;
+			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					NDEBUG,
+					NS_BLOCK_ASSERTIONS,
+					WEBP_USE_THREAD,
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)",
+					"$(SRCROOT)/src",
+				);
+				LLVM_LTO = YES;
+			};
+			name = Release;
+		};
+		WEBP0000000000000000TCGD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEAD_CODE_STRIPPING = YES;
+				GCC_WARN_UNUSED_FUNCTION = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		WEBP0000000000000000TCGR /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEAD_CODE_STRIPPING = YES;
+				GCC_WARN_UNUSED_FUNCTION = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		WEBP0000000000000000DCGD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		WEBP0000000000000000DCGR /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		WEBP0000000000000000PLST /* Build configuration list for PBXProject "libwebp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				WEBP0000000000000000PCGD /* Debug */,
+				WEBP0000000000000000PCGR /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		WEBP0000000000000000TLST /* Build configuration list for PBXNativeTarget "cwebp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				WEBP0000000000000000TCGD /* Debug */,
+				WEBP0000000000000000TCGR /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		WEBP0000000000000000DLST /* Build configuration list for PBXLegacyTarget "download" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				WEBP0000000000000000DCGD /* Debug */,
+				WEBP0000000000000000DCGR /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = WEBP0000000000000000PROJ /* Project object */;
+}


### PR DESCRIPTION
Implements #406. You wrote there that WebP having full browser support made this worth revisiting — this is a concrete attempt at it, scoped to the part that is genuinely lossless.

### What it does

Most WebP files in the wild were written at cwebp's default effort. Re-encoding them at the maximum (`-z 9`) is strictly lossless and often much smaller:

| source | before | after | |
|---|---:|---:|---|
| lossless, written at low effort | 12168 | 6726 | −44.7% |
| same with an ICC profile (VP8X) | 15338 | 9896 | −35.5%, profile preserved |
| already written at high effort | 14208 | 14034 | −1.3% |

As with every other tool, the result is only kept when it is smaller.

### Scope: lossless only

Lossy WebP is rejected — there is one WebP encoder, so re-encoding a lossy bitstream can only degrade it. Animations are rejected too; `cwebp` cannot process them.

`File.m` tells them apart by walking the RIFF container rather than sniffing a fixed offset. A plain lossless file has `VP8L` right after the header, but one carrying an ICC profile, EXIF or an alpha channel is wrapped in an extended `VP8X` header, so the chunk list has to be walked to find `VP8L` — and to bail out on `ANIM` or `VP8 `. Malformed and truncated files fall through to a rejection, and the walk is bounded so a file full of tiny chunks can't spin.

### Two cwebp details worth knowing during review

**`-exact` is required.** By default cwebp zeroes the RGB channels of fully transparent pixels. That is invisible once composited, but it destroys data in images that pack information under an alpha mask — sprite sheets, texture atlases, normal maps. On a 64×64 test image written with `exact=True`, omitting the flag changed 4095 of 4096 pixels and took the file from 326 to 28 bytes. With `-exact` it is 62 bytes and pixel-identical. On images without such data the flag costs nothing measurable: the corpus results above are byte-for-byte the same with and without it.

I noticed while checking this that `ZopfliWorker` passes `--lossy_transparent` unconditionally, so ImageOptim already does discard that data for PNG even though `LossyEnabled` defaults to false. I went the other way for WebP because there is no competing tool whose output could preserve it — with PNG at least another optimizer may win. Happy to flip it for consistency if you'd rather.

**`-o` must come before `--`.** cwebp treats the argument after `--` as the input file and stops parsing, so a trailing `-o` is silently swallowed and cwebp exits 0 without writing anything. That failure looks exactly like success.

### Integration

`cwebp` is built from libwebp 1.6.0 as a new subproject following the existing pattern: `libwebp/Makefile` fetches the tarball, `libwebp.xcodeproj` compiles the 129 sources cwebp needs. Only libwebp itself is required — WebP decoding is built in, so the WebP-to-WebP path needs neither libpng nor libjpeg.

There is no checkbox in the preferences window, matching how SVG was added (`SvgoEnabled` isn't in `defaults.plist` either and neither SVG tool has a XIB binding). `WebPEnabled` defaults to true and can be turned off with `defaults write net.pornel.ImageOptim WebPEnabled -bool NO`. Unlike PNG there are no competing tools to choose between, so the toggle would amount to "don't drop WebP files". Glad to add one if you want it — I left the XIB alone deliberately rather than guess at your layout.

### Verification

Seven cases run end-to-end through the app: plain lossless, lossless with alpha, VP8X with an ICC profile, RGB packed under full transparency, lossy, animated, truncated, and a RIFF file that isn't WebP. The four optimisable ones come out pixel-identical to their originals; the rest are refused and left untouched.

One thing to expect when you build this: on a fresh checkout the first build fails with `Build input file cannot be found: .../libwebp/src/dsp/yuv_sse2.c`, because the `download` target is still fetching while the `cwebp` target scans its inputs. A second build succeeds. This is the same race the existing subprojects have — I hit the identical thing with `zlib/trees.c` on a fresh clone before touching anything — so I have not tried to fix it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
